### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 MCP server for Google Keep
 
+<a href="https://glama.ai/mcp/servers/@feuerdev/keep-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@feuerdev/keep-mcp/badge" alt="Keep MCP server" />
+</a>
+
 ![keep-mcp](https://github.com/user-attachments/assets/f50c4ae6-4d35-4bb6-a494-51c67385f1b6)
 
 ## How to use


### PR DESCRIPTION
This PR adds a badge for the [Keep MCP](https://glama.ai/mcp/servers/@feuerdev/keep-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@feuerdev/keep-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@feuerdev/keep-mcp/badge" alt="Keep MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.