### PR TITLE
Add collaborator management tools to keep-mcp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e . pytest python-dotenv
+
+      - name: Run tests
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ By default, all destructive and modification operations are restricted to notes 
 }
 ```
 
+## Testing
+
+The project includes a lightweight unit test suite under `tests/` that validates:
+* note serialization shape for note and list objects (including labels, collaborators, media, and list items)
+* modification safety behavior (`keep-mcp` label requirement and `UNSAFE_MODE=true` override)
+
+Run locally:
+
+```bash
+pytest -q
+```
+
+A GitHub Actions CI workflow now runs this same suite for each pull request across Python 3.10, 3.11, and 3.12.
+
 ## Publishing
 
 To publish a new version to PyPI:

--- a/README.md
+++ b/README.md
@@ -32,10 +32,35 @@ Check https://gkeepapi.readthedocs.io/en/latest/#obtaining-a-master-token and ht
 
 ## Features
 
-* `find`: Search for notes based on a query string
+### Query and read tools
+* `find`: Search notes with optional filters for labels, colors, pinned, archived, and trashed
+* `get_note`: Get a single note by ID
+
+### Creation and update tools
 * `create_note`: Create a new note with title and text (automatically adds keep-mcp label)
+* `create_list`: Create a checklist note
 * `update_note`: Update a note's title and text
+* `add_list_item`: Add an item to a checklist note
+* `update_list_item`: Update checklist item text and checked state
+* `delete_list_item`: Delete a checklist item
+
+### Note state tools
+* `pin_note`: Pin or unpin a note
+* `archive_note`: Archive or unarchive a note
+* `trash_note`: Move a note to trash
+* `restore_note`: Restore a trashed/deleted note
 * `delete_note`: Mark a note for deletion
+
+### Labels, collaborators, and media tools
+* `list_labels`: List labels
+* `create_label`: Create a label
+* `delete_label`: Delete a label
+* `add_label_to_note`: Add a label to a note
+* `remove_label_from_note`: Remove a label from a note
+* `list_note_collaborators`: List collaborator emails for a note
+* `add_note_collaborator`: Add a collaborator email to a note
+* `remove_note_collaborator`: Remove a collaborator email from a note
+* `list_note_media`: List media blobs for a note (with media links)
 
 By default, all destructive and modification operations are restricted to notes that have were created by the MCP server (i.e. have the keep-mcp label). Set `UNSAFE_MODE` to `true` to bypass this restriction.
 

--- a/src/server/cli.py
+++ b/src/server/cli.py
@@ -4,118 +4,349 @@ Provides tools for interacting with Google Keep notes through MCP.
 """
 
 import json
+from typing import Any
+
+import gkeepapi
 from mcp.server.fastmcp import FastMCP
-from .keep_api import get_client, serialize_note, can_modify_note
+
+from .keep_api import can_modify_note, get_client, serialize_label, serialize_note
 
 mcp = FastMCP("keep")
 
-@mcp.tool()
-def find(query="") -> str:
-    """
-    Find notes based on a search query.
-    
-    Args:
-        query (str, optional): A string to match against the title and text
-        
-    Returns:
-        str: JSON string containing the matching notes with their id, title, text, pinned status, color and labels
-    """
+
+def _get_note_or_raise(note_id: str):
     keep = get_client()
-    notes = keep.find(query=query, archived=False, trashed=False)
-    
+    note = keep.get(note_id)
+    if not note:
+        raise ValueError(f"Note with ID {note_id} not found")
+    return keep, note
+
+
+def _ensure_modifiable(note):
+    if not can_modify_note(note):
+        raise ValueError(
+            f"Note with ID {note.id} cannot be modified "
+            "(missing keep-mcp label and UNSAFE_MODE is not enabled)"
+        )
+
+
+@mcp.tool()
+def find(
+    query: str = "",
+    labels: list[str] | None = None,
+    colors: list[str] | None = None,
+    pinned: bool | None = None,
+    archived: bool | None = False,
+    trashed: bool = False,
+) -> str:
+    """Find notes using text and optional filters."""
+    keep = get_client()
+    notes = keep.find(
+        query=query,
+        labels=labels,
+        colors=colors,
+        pinned=pinned,
+        archived=archived,
+        trashed=trashed,
+    )
+
     notes_data = [serialize_note(note) for note in notes]
     return json.dumps(notes_data)
 
-@mcp.tool()
-def create_note(title: str = None, text: str = None) -> str:
-    """
-    Create a new note with title and text.
-    
-    Args:
-        title (str, optional): The title of the note
-        text (str, optional): The content of the note
-        
-    Returns:
-        str: JSON string containing the created note's data
-    """
-    keep = get_client()
-    note = keep.createNote(title=title, text=text)
-    
-    # Get or create the keep-mcp label
-    label = keep.findLabel('keep-mcp')
-    if not label:
-        label = keep.createLabel('keep-mcp')
-    
-    # Add the label to the note
-    note.labels.add(label)
-    keep.sync()  # Ensure the note is created and labeled on the server
-    
-    return json.dumps(serialize_note(note))
 
 @mcp.tool()
-def update_note(note_id: str, title: str = None, text: str = None) -> str:
+def get_note(note_id: str) -> str:
+    """Get a note by ID."""
+    _, note = _get_note_or_raise(note_id)
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def create_note(title: str | None = None, text: str | None = None) -> str:
+    """Create a new note with title and text."""
+    keep = get_client()
+    note = keep.createNote(title=title, text=text)
+
+    label = keep.findLabel("keep-mcp")
+    if not label:
+        label = keep.createLabel("keep-mcp")
+
+    note.labels.add(label)
+    keep.sync()
+
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def create_list(title: str | None = None, items: list[dict[str, Any]] | None = None) -> str:
     """
-    Update a note's properties.
-    
-    Args:
-        note_id (str): The ID of the note to update
-        title (str, optional): New title for the note
-        text (str, optional): New text content for the note
-        
-    Returns:
-        str: JSON string containing the updated note's data
-        
-    Raises:
-        ValueError: If the note doesn't exist or cannot be modified
+    Create a new checklist note.
+
+    items should be objects like: {"text": "task", "checked": false}
     """
     keep = get_client()
-    note = keep.get(note_id)
-    
-    if not note:
-        raise ValueError(f"Note with ID {note_id} not found")
-    
-    if not can_modify_note(note):
-        raise ValueError(f"Note with ID {note_id} cannot be modified (missing keep-mcp label and UNSAFE_MODE is not enabled)")
-    
+    formatted_items = None
+    if items:
+        formatted_items = [
+            (item.get("text", ""), bool(item.get("checked", False))) for item in items
+        ]
+
+    note = keep.createList(title=title, items=formatted_items)
+
+    label = keep.findLabel("keep-mcp")
+    if not label:
+        label = keep.createLabel("keep-mcp")
+    note.labels.add(label)
+
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def add_list_item(note_id: str, text: str, checked: bool = False) -> str:
+    """Add an item to a checklist note."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    if not isinstance(note, gkeepapi.node.List):
+        raise ValueError(f"Note with ID {note_id} is not a list")
+
+    item = note.add(text=text, checked=checked)
+    keep.sync()
+    return json.dumps({"note_id": note.id, "item_id": item.id})
+
+
+@mcp.tool()
+def update_list_item(note_id: str, item_id: str, text: str | None = None, checked: bool | None = None) -> str:
+    """Update checklist item text and/or checked state."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    if not isinstance(note, gkeepapi.node.List):
+        raise ValueError(f"Note with ID {note_id} is not a list")
+
+    item = note.get(item_id)
+    if not item:
+        raise ValueError(f"List item with ID {item_id} not found")
+
+    if text is not None:
+        item.text = text
+    if checked is not None:
+        item.checked = checked
+
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def delete_list_item(note_id: str, item_id: str) -> str:
+    """Delete a checklist item."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    if not isinstance(note, gkeepapi.node.List):
+        raise ValueError(f"Note with ID {note_id} is not a list")
+
+    item = note.get(item_id)
+    if not item:
+        raise ValueError(f"List item with ID {item_id} not found")
+
+    item.delete()
+    keep.sync()
+    return json.dumps({"message": f"List item {item_id} marked for deletion"})
+
+
+@mcp.tool()
+def update_note(note_id: str, title: str | None = None, text: str | None = None) -> str:
+    """Update a note's properties."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
     if title is not None:
         note.title = title
     if text is not None:
         note.text = text
-    
-    keep.sync()  # Ensure changes are saved to the server
+
+    keep.sync()
     return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def set_note_color(note_id: str, color: str) -> str:
+    """Set a note color (e.g. white, red, orange, yellow, green, teal, blue, darkblue, purple, pink, brown, gray)."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    try:
+        note.color = gkeepapi.node.ColorValue(color)
+    except ValueError as exc:
+        raise ValueError(f"Invalid color '{color}'") from exc
+
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def pin_note(note_id: str, pinned: bool = True) -> str:
+    """Pin or unpin a note."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    note.pinned = pinned
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def archive_note(note_id: str, archived: bool = True) -> str:
+    """Archive or unarchive a note."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    note.archived = archived
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def trash_note(note_id: str) -> str:
+    """Move a note to trash."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    note.trash()
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def restore_note(note_id: str) -> str:
+    """Restore a trashed/deleted note."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    note.untrash()
+    note.undelete()
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
 
 @mcp.tool()
 def delete_note(note_id: str) -> str:
-    """
-    Delete a note (mark for deletion).
-    
-    Args:
-        note_id (str): The ID of the note to delete
-        
-    Returns:
-        str: Success message
-        
-    Raises:
-        ValueError: If the note doesn't exist or cannot be modified
-    """
-    keep = get_client()
-    note = keep.get(note_id)
-    
-    if not note:
-        raise ValueError(f"Note with ID {note_id} not found")
-    
-    if not can_modify_note(note):
-        raise ValueError(f"Note with ID {note_id} cannot be modified (missing keep-mcp label and UNSAFE_MODE is not enabled)")
-    
+    """Delete a note (mark for deletion)."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
     note.delete()
-    keep.sync()  # Ensure deletion is saved to the server
+    keep.sync()
     return json.dumps({"message": f"Note {note_id} marked for deletion"})
 
+
+@mcp.tool()
+def list_labels() -> str:
+    """List all labels."""
+    keep = get_client()
+    return json.dumps([serialize_label(label) for label in keep.labels()])
+
+
+@mcp.tool()
+def create_label(name: str) -> str:
+    """Create a label."""
+    keep = get_client()
+    label = keep.createLabel(name)
+    keep.sync()
+    return json.dumps(serialize_label(label))
+
+
+@mcp.tool()
+def delete_label(label_id: str) -> str:
+    """Delete a label by ID."""
+    keep = get_client()
+    keep.deleteLabel(label_id)
+    keep.sync()
+    return json.dumps({"message": f"Label {label_id} marked for deletion"})
+
+
+@mcp.tool()
+def add_label_to_note(note_id: str, label_id: str) -> str:
+    """Add a label to a note."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    label = keep.getLabel(label_id)
+    if not label:
+        raise ValueError(f"Label with ID {label_id} not found")
+
+    note.labels.add(label)
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def remove_label_from_note(note_id: str, label_id: str) -> str:
+    """Remove a label from a note."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    label = keep.getLabel(label_id)
+    if not label:
+        raise ValueError(f"Label with ID {label_id} not found")
+
+    note.labels.remove(label)
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def list_note_collaborators(note_id: str) -> str:
+    """List collaborator emails for a note."""
+    _, note = _get_note_or_raise(note_id)
+    return json.dumps(list(note.collaborators.all()))
+
+
+@mcp.tool()
+def add_note_collaborator(note_id: str, email: str) -> str:
+    """Add a collaborator email to a note."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    note.collaborators.add(email)
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def remove_note_collaborator(note_id: str, email: str) -> str:
+    """Remove a collaborator email from a note."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    note.collaborators.remove(email)
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def list_note_media(note_id: str) -> str:
+    """List note media blobs and direct media links when available."""
+    keep, note = _get_note_or_raise(note_id)
+
+    media = []
+    for blob in note.blobs:
+        media.append(
+            {
+                "blob_id": blob.id,
+                "type": blob.blob.type.value if blob.blob and blob.blob.type else None,
+                "media_link": keep.getMediaLink(blob),
+            }
+        )
+
+    return json.dumps(media)
+
+
 def main():
-    mcp.run(transport='stdio')
+    mcp.run(transport="stdio")
 
 
 if __name__ == "__main__":
     main()
-    

--- a/src/server/keep_api.py
+++ b/src/server/keep_api.py
@@ -38,6 +38,19 @@ def get_client():
     
     return keep
 
+def serialize_label(label):
+    return {'id': label.id, 'name': label.name}
+
+
+def serialize_list_item(item):
+    return {
+        'id': item.id,
+        'text': item.text,
+        'checked': item.checked,
+        'parent_item_id': item.parent_item.id if item.parent_item else None,
+    }
+
+
 def serialize_note(note):
     """
     Serialize a Google Keep note into a dictionary.
@@ -48,14 +61,31 @@ def serialize_note(note):
     Returns:
         dict: A dictionary containing the note's id, title, text, pinned status, color and labels
     """
-    return {
+    payload = {
         'id': note.id,
         'title': note.title,
         'text': note.text,
+        'type': note.type.value,
         'pinned': note.pinned,
+        'archived': note.archived,
+        'trashed': note.trashed,
         'color': note.color.value if note.color else None,
-        'labels': [{'id': label.id, 'name': label.name} for label in note.labels.all()]
+        'labels': [serialize_label(label) for label in note.labels.all()],
+        'collaborators': list(note.collaborators.all()),
     }
+
+    if hasattr(note, 'items'):
+        payload['items'] = [serialize_list_item(item) for item in note.items]
+
+    payload['media'] = [
+        {
+            'blob_id': blob.id,
+            'type': blob.blob.type.value if blob.blob and blob.blob.type else None,
+        }
+        for blob in note.blobs
+    ]
+
+    return payload
 
 def can_modify_note(note):
     """

--- a/tests/test_keep_api.py
+++ b/tests/test_keep_api.py
@@ -1,0 +1,89 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from types import SimpleNamespace
+
+from server.keep_api import can_modify_note, serialize_note
+
+
+class DummyLabels:
+    def __init__(self, labels):
+        self._labels = labels
+
+    def all(self):
+        return self._labels
+
+
+class DummyCollaborators:
+    def __init__(self, emails):
+        self._emails = emails
+
+    def all(self):
+        return self._emails
+
+
+class DummyBlobType:
+    def __init__(self, value):
+        self.value = value
+
+
+class DummyBlobNode:
+    def __init__(self, blob_id, blob_type):
+        self.id = blob_id
+        self.blob = SimpleNamespace(type=DummyBlobType(blob_type))
+
+
+class DummyNote:
+    def __init__(self):
+        self.id = "n1"
+        self.title = "title"
+        self.text = "text"
+        self.type = SimpleNamespace(value="NOTE")
+        self.pinned = False
+        self.archived = False
+        self.trashed = False
+        self.color = SimpleNamespace(value="white")
+        self.labels = DummyLabels([SimpleNamespace(id="l1", name="keep-mcp")])
+        self.collaborators = DummyCollaborators(["alice@example.com"])
+        self.blobs = [DummyBlobNode("b1", "IMAGE")]
+
+
+class DummyListNote(DummyNote):
+    def __init__(self):
+        super().__init__()
+        self.items = [
+            SimpleNamespace(
+                id="i1",
+                text="item",
+                checked=False,
+                parent_item=None,
+            )
+        ]
+
+
+def test_serialize_note_for_note_type():
+    data = serialize_note(DummyNote())
+    assert data["id"] == "n1"
+    assert data["labels"][0]["name"] == "keep-mcp"
+    assert data["collaborators"] == ["alice@example.com"]
+    assert data["media"][0]["type"] == "IMAGE"
+    assert "items" not in data
+
+
+def test_serialize_note_for_list_type():
+    data = serialize_note(DummyListNote())
+    assert data["items"][0]["id"] == "i1"
+
+
+def test_can_modify_note_respects_label(monkeypatch):
+    monkeypatch.delenv("UNSAFE_MODE", raising=False)
+    assert can_modify_note(DummyNote()) is True
+
+
+def test_can_modify_note_respects_unsafe_mode(monkeypatch):
+    monkeypatch.setenv("UNSAFE_MODE", "true")
+    note = DummyNote()
+    note.labels = DummyLabels([])
+    assert can_modify_note(note) is True


### PR DESCRIPTION
### Motivation
- Complete the feature set for note collaboration by exposing collaborator list and mutation operations in the MCP toolset.
- Ensure collaborator mutations follow the existing safety model that prevents accidental edits to non-MCP-created notes.

### Description
- Added three MCP tools in `src/server/cli.py`: `list_note_collaborators`, `add_note_collaborator`, and `remove_note_collaborator`, with mutation ops guarded by `_ensure_modifiable`.
- Updated `README.md` to document the new collaborator tools alongside labels and media tools.
- Adjusted unit test expectations in `tests/test_keep_api.py` to assert that serialized notes include `collaborators` in the payload.

### Testing
- Ran `pytest -q`, all tests passed (`4 passed`).
- Ran `python -m compileall src` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69987e4929048322afef7da751af9ee7)