### PR TITLE
Increase test coverage for keep-mcp CLI and client bootstrap paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e . pytest pytest-cov ruff python-dotenv
+
+      - name: Lint
+        run: ruff check .
+
+      - name: Run tests with coverage
+        run: pytest -q --cov=src/server --cov-report=term-missing --cov-fail-under=70
+
+      - name: Bytecode sanity
+        run: python -m compileall src

--- a/README.md
+++ b/README.md
@@ -32,10 +32,35 @@ Check https://gkeepapi.readthedocs.io/en/latest/#obtaining-a-master-token and ht
 
 ## Features
 
-* `find`: Search for notes based on a query string
+### Query and read tools
+* `find`: Search notes with optional filters for labels, colors, pinned, archived, and trashed
+* `get_note`: Get a single note by ID
+
+### Creation and update tools
 * `create_note`: Create a new note with title and text (automatically adds keep-mcp label)
+* `create_list`: Create a checklist note
 * `update_note`: Update a note's title and text
+* `add_list_item`: Add an item to a checklist note
+* `update_list_item`: Update checklist item text and checked state
+* `delete_list_item`: Delete a checklist item
+
+### Note state tools
+* `pin_note`: Pin or unpin a note
+* `archive_note`: Archive or unarchive a note
+* `trash_note`: Move a note to trash
+* `restore_note`: Restore a trashed/deleted note
 * `delete_note`: Mark a note for deletion
+
+### Labels, collaborators, and media tools
+* `list_labels`: List labels
+* `create_label`: Create a label
+* `delete_label`: Delete a label
+* `add_label_to_note`: Add a label to a note
+* `remove_label_from_note`: Remove a label from a note
+* `list_note_collaborators`: List collaborator emails for a note
+* `add_note_collaborator`: Add a collaborator email to a note
+* `remove_note_collaborator`: Remove a collaborator email from a note
+* `list_note_media`: List media blobs for a note (with media links)
 
 By default, all destructive and modification operations are restricted to notes that have were created by the MCP server (i.e. have the keep-mcp label). Set `UNSAFE_MODE` to `true` to bypass this restriction.
 
@@ -45,6 +70,47 @@ By default, all destructive and modification operations are restricted to notes 
   "UNSAFE_MODE": "true"
 }
 ```
+
+## Testing
+
+### Unit tests (default)
+The project includes a lightweight unit test suite under `tests/`.
+
+It validates:
+* note serialization shape for note and list objects (including labels, collaborators, media, and list items)
+* modification safety behavior (`keep-mcp` label requirement and `UNSAFE_MODE=true` override)
+* MCP tool behavior in `src/server/cli.py` using mocked Keep client objects (tool happy paths and key error paths)
+
+Run locally:
+
+```bash
+pytest -q
+```
+
+### Smoke test against a real Keep account
+For additional confidence, run a basic lifecycle smoke test against a dedicated test account:
+
+```bash
+GOOGLE_EMAIL="you@example.com" \
+GOOGLE_MASTER_TOKEN="..." \
+python scripts/smoke_test.py
+```
+
+What it does:
+* create note
+* update note
+* pin/unpin
+* archive/unarchive
+* trash/restore
+* delete
+
+This script is intended for manual verification and is not run in CI.
+
+### CI checks
+GitHub Actions runs on every pull request and executes:
+* lint (`ruff check .`)
+* unit tests with coverage (`pytest -q --cov=src/server --cov-report=term-missing --cov-fail-under=70`)
+* bytecode sanity (`python -m compileall src`)
 
 ## Publishing
 

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -1,0 +1,57 @@
+"""Basic real-account smoke test for keep-mcp server logic.
+
+Usage:
+  GOOGLE_EMAIL=... GOOGLE_MASTER_TOKEN=... python scripts/smoke_test.py
+
+This script performs a minimal lifecycle against Google Keep:
+- create note
+- update note
+- pin/unpin
+- archive/unarchive
+- trash/restore
+- delete
+
+It is intended for manual verification, not CI.
+"""
+
+import json
+import os
+
+from server import cli
+
+
+def main() -> None:
+    if not os.getenv("GOOGLE_EMAIL") or not os.getenv("GOOGLE_MASTER_TOKEN"):
+        raise SystemExit("Set GOOGLE_EMAIL and GOOGLE_MASTER_TOKEN before running smoke test")
+
+    print("Creating note...")
+    created = json.loads(cli.create_note(title="keep-mcp smoke", text="hello"))
+    note_id = created["id"]
+    print("Created:", note_id)
+
+    print("Updating note...")
+    updated = json.loads(cli.update_note(note_id, title="keep-mcp smoke updated", text="world"))
+    assert updated["title"] == "keep-mcp smoke updated"
+
+    print("Pin/unpin...")
+    assert json.loads(cli.pin_note(note_id, True))["pinned"] is True
+    assert json.loads(cli.pin_note(note_id, False))["pinned"] is False
+
+    print("Archive/unarchive...")
+    assert json.loads(cli.archive_note(note_id, True))["archived"] is True
+    assert json.loads(cli.archive_note(note_id, False))["archived"] is False
+
+    print("Trash/restore...")
+    assert json.loads(cli.trash_note(note_id))["trashed"] is True
+    restored = json.loads(cli.restore_note(note_id))
+    assert restored["trashed"] is False
+
+    print("Deleting note...")
+    delete_msg = json.loads(cli.delete_note(note_id))
+    assert "marked for deletion" in delete_msg["message"]
+
+    print("Smoke test finished successfully")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/server/cli.py
+++ b/src/server/cli.py
@@ -30,6 +30,20 @@ def _ensure_modifiable(note):
         )
 
 
+def _normalize_colors(colors: list[str] | None):
+    if colors is None:
+        return None
+
+    normalized_colors = []
+    for color in colors:
+        try:
+            normalized_colors.append(gkeepapi.node.ColorValue(color))
+        except ValueError as exc:
+            raise ValueError(f"Invalid color '{color}'") from exc
+
+    return normalized_colors
+
+
 @mcp.tool()
 def find(
     query: str = "",
@@ -41,10 +55,11 @@ def find(
 ) -> str:
     """Find notes using text and optional filters."""
     keep = get_client()
+    normalized_colors = _normalize_colors(colors)
     notes = keep.find(
         query=query,
         labels=labels,
-        colors=colors,
+        colors=normalized_colors,
         pinned=pinned,
         archived=archived,
         trashed=trashed,

--- a/src/server/cli.py
+++ b/src/server/cli.py
@@ -4,118 +4,349 @@ Provides tools for interacting with Google Keep notes through MCP.
 """
 
 import json
+from typing import Any
+
+import gkeepapi
 from mcp.server.fastmcp import FastMCP
-from .keep_api import get_client, serialize_note, can_modify_note
+
+from .keep_api import can_modify_note, get_client, serialize_label, serialize_note
 
 mcp = FastMCP("keep")
 
-@mcp.tool()
-def find(query="") -> str:
-    """
-    Find notes based on a search query.
-    
-    Args:
-        query (str, optional): A string to match against the title and text
-        
-    Returns:
-        str: JSON string containing the matching notes with their id, title, text, pinned status, color and labels
-    """
+
+def _get_note_or_raise(note_id: str):
     keep = get_client()
-    notes = keep.find(query=query, archived=False, trashed=False)
-    
+    note = keep.get(note_id)
+    if not note:
+        raise ValueError(f"Note with ID {note_id} not found")
+    return keep, note
+
+
+def _ensure_modifiable(note):
+    if not can_modify_note(note):
+        raise ValueError(
+            f"Note with ID {note.id} cannot be modified "
+            "(missing keep-mcp label and UNSAFE_MODE is not enabled)"
+        )
+
+
+@mcp.tool()
+def find(
+    query: str = "",
+    labels: list[str] | None = None,
+    colors: list[str] | None = None,
+    pinned: bool | None = None,
+    archived: bool | None = False,
+    trashed: bool = False,
+) -> str:
+    """Find notes using text and optional filters."""
+    keep = get_client()
+    notes = keep.find(
+        query=query,
+        labels=labels,
+        colors=colors,
+        pinned=pinned,
+        archived=archived,
+        trashed=trashed,
+    )
+
     notes_data = [serialize_note(note) for note in notes]
     return json.dumps(notes_data)
 
-@mcp.tool()
-def create_note(title: str = None, text: str = None) -> str:
-    """
-    Create a new note with title and text.
-    
-    Args:
-        title (str, optional): The title of the note
-        text (str, optional): The content of the note
-        
-    Returns:
-        str: JSON string containing the created note's data
-    """
-    keep = get_client()
-    note = keep.createNote(title=title, text=text)
-    
-    # Get or create the keep-mcp label
-    label = keep.findLabel('keep-mcp')
-    if not label:
-        label = keep.createLabel('keep-mcp')
-    
-    # Add the label to the note
-    note.labels.add(label)
-    keep.sync()  # Ensure the note is created and labeled on the server
-    
-    return json.dumps(serialize_note(note))
 
 @mcp.tool()
-def update_note(note_id: str, title: str = None, text: str = None) -> str:
+def get_note(note_id: str) -> str:
+    """Get a note by ID."""
+    _, note = _get_note_or_raise(note_id)
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def create_note(title: str | None = None, text: str | None = None) -> str:
+    """Create a new note with title and text."""
+    keep = get_client()
+    note = keep.createNote(title=title, text=text)
+
+    label = keep.findLabel("keep-mcp")
+    if not label:
+        label = keep.createLabel("keep-mcp")
+
+    note.labels.add(label)
+    keep.sync()
+
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def create_list(title: str | None = None, items: list[dict[str, Any]] | None = None) -> str:
     """
-    Update a note's properties.
-    
-    Args:
-        note_id (str): The ID of the note to update
-        title (str, optional): New title for the note
-        text (str, optional): New text content for the note
-        
-    Returns:
-        str: JSON string containing the updated note's data
-        
-    Raises:
-        ValueError: If the note doesn't exist or cannot be modified
+    Create a new checklist note.
+
+    items should be objects like: {"text": "task", "checked": false}
     """
     keep = get_client()
-    note = keep.get(note_id)
-    
-    if not note:
-        raise ValueError(f"Note with ID {note_id} not found")
-    
-    if not can_modify_note(note):
-        raise ValueError(f"Note with ID {note_id} cannot be modified (missing keep-mcp label and UNSAFE_MODE is not enabled)")
-    
+    formatted_items = None
+    if items:
+        formatted_items = [
+            (item.get("text", ""), bool(item.get("checked", False))) for item in items
+        ]
+
+    note = keep.createList(title=title, items=formatted_items)
+
+    label = keep.findLabel("keep-mcp")
+    if not label:
+        label = keep.createLabel("keep-mcp")
+    note.labels.add(label)
+
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def add_list_item(note_id: str, text: str, checked: bool = False) -> str:
+    """Add an item to a checklist note."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    if not isinstance(note, gkeepapi.node.List):
+        raise ValueError(f"Note with ID {note_id} is not a list")
+
+    item = note.add(text=text, checked=checked)
+    keep.sync()
+    return json.dumps({"note_id": note.id, "item_id": item.id})
+
+
+@mcp.tool()
+def update_list_item(note_id: str, item_id: str, text: str | None = None, checked: bool | None = None) -> str:
+    """Update checklist item text and/or checked state."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    if not isinstance(note, gkeepapi.node.List):
+        raise ValueError(f"Note with ID {note_id} is not a list")
+
+    item = note.get(item_id)
+    if not item:
+        raise ValueError(f"List item with ID {item_id} not found")
+
+    if text is not None:
+        item.text = text
+    if checked is not None:
+        item.checked = checked
+
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def delete_list_item(note_id: str, item_id: str) -> str:
+    """Delete a checklist item."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    if not isinstance(note, gkeepapi.node.List):
+        raise ValueError(f"Note with ID {note_id} is not a list")
+
+    item = note.get(item_id)
+    if not item:
+        raise ValueError(f"List item with ID {item_id} not found")
+
+    item.delete()
+    keep.sync()
+    return json.dumps({"message": f"List item {item_id} marked for deletion"})
+
+
+@mcp.tool()
+def update_note(note_id: str, title: str | None = None, text: str | None = None) -> str:
+    """Update a note's properties."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
     if title is not None:
         note.title = title
     if text is not None:
         note.text = text
-    
-    keep.sync()  # Ensure changes are saved to the server
+
+    keep.sync()
     return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def set_note_color(note_id: str, color: str) -> str:
+    """Set a note color (e.g. white, red, orange, yellow, green, teal, blue, darkblue, purple, pink, brown, gray)."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    try:
+        note.color = gkeepapi.node.ColorValue(color)
+    except ValueError as exc:
+        raise ValueError(f"Invalid color '{color}'") from exc
+
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def pin_note(note_id: str, pinned: bool = True) -> str:
+    """Pin or unpin a note."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    note.pinned = pinned
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def archive_note(note_id: str, archived: bool = True) -> str:
+    """Archive or unarchive a note."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    note.archived = archived
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def trash_note(note_id: str) -> str:
+    """Move a note to trash."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    note.trash()
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def restore_note(note_id: str) -> str:
+    """Restore a trashed/deleted note."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    note.untrash()
+    note.undelete()
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
 
 @mcp.tool()
 def delete_note(note_id: str) -> str:
-    """
-    Delete a note (mark for deletion).
-    
-    Args:
-        note_id (str): The ID of the note to delete
-        
-    Returns:
-        str: Success message
-        
-    Raises:
-        ValueError: If the note doesn't exist or cannot be modified
-    """
-    keep = get_client()
-    note = keep.get(note_id)
-    
-    if not note:
-        raise ValueError(f"Note with ID {note_id} not found")
-    
-    if not can_modify_note(note):
-        raise ValueError(f"Note with ID {note_id} cannot be modified (missing keep-mcp label and UNSAFE_MODE is not enabled)")
-    
+    """Delete a note (mark for deletion)."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
     note.delete()
-    keep.sync()  # Ensure deletion is saved to the server
+    keep.sync()
     return json.dumps({"message": f"Note {note_id} marked for deletion"})
 
+
+@mcp.tool()
+def list_labels() -> str:
+    """List all labels."""
+    keep = get_client()
+    return json.dumps([serialize_label(label) for label in keep.labels()])
+
+
+@mcp.tool()
+def create_label(name: str) -> str:
+    """Create a label."""
+    keep = get_client()
+    label = keep.createLabel(name)
+    keep.sync()
+    return json.dumps(serialize_label(label))
+
+
+@mcp.tool()
+def delete_label(label_id: str) -> str:
+    """Delete a label by ID."""
+    keep = get_client()
+    keep.deleteLabel(label_id)
+    keep.sync()
+    return json.dumps({"message": f"Label {label_id} marked for deletion"})
+
+
+@mcp.tool()
+def add_label_to_note(note_id: str, label_id: str) -> str:
+    """Add a label to a note."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    label = keep.getLabel(label_id)
+    if not label:
+        raise ValueError(f"Label with ID {label_id} not found")
+
+    note.labels.add(label)
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def remove_label_from_note(note_id: str, label_id: str) -> str:
+    """Remove a label from a note."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    label = keep.getLabel(label_id)
+    if not label:
+        raise ValueError(f"Label with ID {label_id} not found")
+
+    note.labels.remove(label)
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def list_note_collaborators(note_id: str) -> str:
+    """List collaborator emails for a note."""
+    _, note = _get_note_or_raise(note_id)
+    return json.dumps(list(note.collaborators.all()))
+
+
+@mcp.tool()
+def add_note_collaborator(note_id: str, email: str) -> str:
+    """Add a collaborator email to a note."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    note.collaborators.add(email)
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def remove_note_collaborator(note_id: str, email: str) -> str:
+    """Remove a collaborator email from a note."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    note.collaborators.remove(email)
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def list_note_media(note_id: str) -> str:
+    """List note media blobs and direct media links when available."""
+    keep, note = _get_note_or_raise(note_id)
+
+    media = []
+    for blob in note.blobs:
+        media.append(
+            {
+                "blob_id": blob.id,
+                "type": blob.blob.type.value if blob.blob and blob.blob.type else None,
+                "media_link": keep.getMediaLink(blob),
+            }
+        )
+
+    return json.dumps(media)
+
+
 def main():
-    mcp.run(transport='stdio')
+    mcp.run(transport="stdio")
 
 
 if __name__ == "__main__":
     main()
-    

--- a/src/server/keep_api.py
+++ b/src/server/keep_api.py
@@ -38,6 +38,19 @@ def get_client():
     
     return keep
 
+def serialize_label(label):
+    return {'id': label.id, 'name': label.name}
+
+
+def serialize_list_item(item):
+    return {
+        'id': item.id,
+        'text': item.text,
+        'checked': item.checked,
+        'parent_item_id': item.parent_item.id if item.parent_item else None,
+    }
+
+
 def serialize_note(note):
     """
     Serialize a Google Keep note into a dictionary.
@@ -48,14 +61,31 @@ def serialize_note(note):
     Returns:
         dict: A dictionary containing the note's id, title, text, pinned status, color and labels
     """
-    return {
+    payload = {
         'id': note.id,
         'title': note.title,
         'text': note.text,
+        'type': note.type.value,
         'pinned': note.pinned,
+        'archived': note.archived,
+        'trashed': note.trashed,
         'color': note.color.value if note.color else None,
-        'labels': [{'id': label.id, 'name': label.name} for label in note.labels.all()]
+        'labels': [serialize_label(label) for label in note.labels.all()],
+        'collaborators': list(note.collaborators.all()),
     }
+
+    if hasattr(note, 'items'):
+        payload['items'] = [serialize_list_item(item) for item in note.items]
+
+    payload['media'] = [
+        {
+            'blob_id': blob.id,
+            'type': blob.blob.type.value if blob.blob and blob.blob.type else None,
+        }
+        for blob in note.blobs
+    ]
+
+    return payload
 
 def can_modify_note(note):
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -200,7 +200,17 @@ def test_find_forwards_filters(keep):
     )
     assert keep.last_find_kwargs["query"] == "q"
     assert keep.last_find_kwargs["labels"] == ["l1"]
+    assert [color.value for color in keep.last_find_kwargs["colors"]] == ["red"]
     assert isinstance(result, list)
+
+
+def test_find_invalid_color_raises(keep, monkeypatch):
+    def bad_color(_):
+        raise ValueError("bad")
+
+    monkeypatch.setattr(cli.gkeepapi.node, "ColorValue", bad_color)
+    with pytest.raises(ValueError, match="Invalid color 'invalid'"):
+        cli.find(colors=["invalid"])
 
 
 def test_get_note(keep):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,346 @@
+import json
+
+import pytest
+
+from server import cli
+
+
+class DummyLabel:
+    def __init__(self, label_id="l1", name="keep-mcp"):
+        self.id = label_id
+        self.name = name
+
+
+class DummyLabels:
+    def __init__(self):
+        self._labels = []
+
+    def add(self, label):
+        self._labels.append(label)
+
+    def remove(self, label):
+        self._labels = [existing for existing in self._labels if existing.id != label.id]
+
+    def all(self):
+        return self._labels
+
+
+class DummyCollaborators:
+    def __init__(self):
+        self._emails = []
+
+    def all(self):
+        return list(self._emails)
+
+    def add(self, email):
+        self._emails.append(email)
+
+    def remove(self, email):
+        self._emails = [value for value in self._emails if value != email]
+
+
+class DummyBlobType:
+    def __init__(self, value="IMAGE"):
+        self.value = value
+
+
+class DummyBlobInner:
+    def __init__(self):
+        self.type = DummyBlobType("IMAGE")
+
+
+class DummyBlob:
+    def __init__(self, blob_id="b1"):
+        self.id = blob_id
+        self.blob = DummyBlobInner()
+
+
+class DummyItem:
+    def __init__(self, item_id: str, text: str, checked: bool):
+        self.id = item_id
+        self.text = text
+        self.checked = checked
+        self.parent_item = None
+
+    def delete(self):
+        self.deleted = True
+
+
+class DummyNote:
+    def __init__(self, note_id="n1"):
+        self.id = note_id
+        self.title = "title"
+        self.text = "text"
+        self.pinned = False
+        self.archived = False
+        self.trashed = False
+        self.type = type("T", (), {"value": "NOTE"})()
+        self.color = type("C", (), {"value": "white"})()
+        self.labels = DummyLabels()
+        self.collaborators = DummyCollaborators()
+        self.blobs = [DummyBlob()]
+        self.deleted = False
+
+    def delete(self):
+        self.deleted = True
+
+    def trash(self):
+        self.trashed = True
+
+    def untrash(self):
+        self.trashed = False
+
+    def undelete(self):
+        self.deleted = False
+
+
+class DummyList(DummyNote):
+    def __init__(self, note_id="list1"):
+        super().__init__(note_id)
+        self.type = type("T", (), {"value": "LIST"})()
+        self.items = []
+
+    def add(self, text, checked=False):
+        item = DummyItem(f"i{len(self.items)+1}", text, checked)
+        self.items.append(item)
+        return item
+
+    def get(self, item_id):
+        for item in self.items:
+            if item.id == item_id:
+                return item
+        return None
+
+
+class DummyKeep:
+    def __init__(self):
+        self.notes = {}
+        self._labels = {"l1": DummyLabel("l1", "keep-mcp")}
+        self.sync_calls = 0
+
+    def sync(self):
+        self.sync_calls += 1
+
+    def find(self, **kwargs):
+        self.last_find_kwargs = kwargs
+        return list(self.notes.values())
+
+    def get(self, note_id):
+        return self.notes.get(note_id)
+
+    def createNote(self, title=None, text=None):
+        note = DummyNote("created")
+        note.title = title
+        note.text = text
+        self.notes[note.id] = note
+        return note
+
+    def createList(self, title=None, items=None):
+        note = DummyList("created_list")
+        note.title = title
+        if items:
+            for text, checked in items:
+                note.add(text, checked)
+        self.notes[note.id] = note
+        return note
+
+    def findLabel(self, name):
+        for label in self._labels.values():
+            if label.name == name:
+                return label
+        return None
+
+    def createLabel(self, name):
+        label = DummyLabel("new", name)
+        self._labels[label.id] = label
+        return label
+
+    def labels(self):
+        return list(self._labels.values())
+
+    def getLabel(self, label_id):
+        return self._labels.get(label_id)
+
+    def deleteLabel(self, label_id):
+        self._labels.pop(label_id, None)
+
+    def getMediaLink(self, blob):
+        return f"https://media/{blob.id}"
+
+
+@pytest.fixture()
+def keep(monkeypatch):
+    keep = DummyKeep()
+    keep.notes["n1"] = DummyNote("n1")
+    keep.notes["n1"].labels.add(DummyLabel("l1", "keep-mcp"))
+    keep.notes["list1"] = DummyList("list1")
+    keep.notes["list1"].labels.add(DummyLabel("l1", "keep-mcp"))
+    keep.notes["list1"].add("existing", checked=False)
+
+    monkeypatch.setattr(cli, "get_client", lambda: keep)
+    monkeypatch.setattr(cli.gkeepapi.node, "List", DummyList)
+    monkeypatch.setattr(
+        cli.gkeepapi.node,
+        "ColorValue",
+        lambda color: type("Color", (), {"value": color})(),
+    )
+    return keep
+
+
+def test_find_forwards_filters(keep):
+    result = json.loads(
+        cli.find(
+            query="q",
+            labels=["l1"],
+            colors=["red"],
+            pinned=True,
+            archived=False,
+            trashed=False,
+        )
+    )
+    assert keep.last_find_kwargs["query"] == "q"
+    assert keep.last_find_kwargs["labels"] == ["l1"]
+    assert isinstance(result, list)
+
+
+def test_get_note(keep):
+    data = json.loads(cli.get_note("n1"))
+    assert data["id"] == "n1"
+
+
+def test_create_note_labels_and_sync(keep):
+    data = json.loads(cli.create_note("t", "body"))
+    assert data["id"] == "created"
+    assert keep.sync_calls == 1
+
+
+def test_create_note_creates_label_when_missing(keep):
+    keep._labels = {}
+    data = json.loads(cli.create_note("t", "body"))
+    assert data["labels"][0]["name"] == "keep-mcp"
+
+
+def test_create_list_variants(keep):
+    data = json.loads(cli.create_list("list"))
+    assert data["id"] == "created_list"
+    data_with_items = json.loads(
+        cli.create_list("list", items=[{"text": "a", "checked": True}])
+    )
+    assert data_with_items["items"][0]["checked"] is True
+
+
+def test_update_note_updates_fields(keep):
+    data = json.loads(cli.update_note("n1", title="new", text="changed"))
+    assert data["title"] == "new"
+    assert data["text"] == "changed"
+
+
+def test_update_note_not_found_raises(keep):
+    with pytest.raises(ValueError, match="not found"):
+        cli.update_note("missing", title="x")
+
+
+def test_list_item_roundtrip(keep):
+    add = json.loads(cli.add_list_item("list1", "task", checked=True))
+    item_id = add["item_id"]
+    updated = json.loads(
+        cli.update_list_item("list1", item_id, text="task2", checked=False)
+    )
+    assert any(item["id"] == item_id for item in updated["items"])
+
+
+def test_update_list_item_missing_item_raises(keep):
+    with pytest.raises(ValueError, match="not found"):
+        cli.update_list_item("list1", "missing", text="x")
+
+
+def test_delete_list_item_paths(keep):
+    with pytest.raises(ValueError, match="not found"):
+        cli.delete_list_item("list1", "missing")
+
+    new_item_id = json.loads(cli.add_list_item("list1", "task"))["item_id"]
+    data = json.loads(cli.delete_list_item("list1", new_item_id))
+    assert "marked for deletion" in data["message"]
+
+
+def test_list_item_requires_list_type(keep):
+    with pytest.raises(ValueError, match="not a list"):
+        cli.add_list_item("n1", "x")
+
+
+def test_set_note_color_validates(keep, monkeypatch):
+    def bad_color(_):
+        raise ValueError("bad")
+
+    monkeypatch.setattr(cli.gkeepapi.node, "ColorValue", bad_color)
+    with pytest.raises(ValueError, match="Invalid color"):
+        cli.set_note_color("n1", "invalid")
+
+
+def test_note_state_transitions(keep):
+    assert json.loads(cli.set_note_color("n1", "red"))["color"] == "red"
+    assert json.loads(cli.pin_note("n1", True))["pinned"] is True
+    assert json.loads(cli.archive_note("n1", True))["archived"] is True
+    assert json.loads(cli.trash_note("n1"))["trashed"] is True
+    assert json.loads(cli.restore_note("n1"))["trashed"] is False
+
+
+def test_delete_note_marks_deleted(keep):
+    msg = json.loads(cli.delete_note("n1"))
+    assert "marked for deletion" in msg["message"]
+
+
+def test_label_crud_and_missing_label_errors(keep):
+    labels = json.loads(cli.list_labels())
+    assert labels
+
+    created = json.loads(cli.create_label("other"))
+    assert created["name"] == "other"
+    message = json.loads(cli.delete_label(created["id"]))
+    assert "marked for deletion" in message["message"]
+
+    with pytest.raises(ValueError, match="Label with ID bad not found"):
+        cli.add_label_to_note("n1", "bad")
+    with pytest.raises(ValueError, match="Label with ID bad not found"):
+        cli.remove_label_from_note("n1", "bad")
+
+
+def test_label_add_remove(keep):
+    keep._labels["l2"] = DummyLabel("l2", "other")
+    add = json.loads(cli.add_label_to_note("n1", "l2"))
+    assert any(label["id"] == "l2" for label in add["labels"])
+    remove = json.loads(cli.remove_label_from_note("n1", "l2"))
+    assert all(label["id"] != "l2" for label in remove["labels"])
+
+
+def test_collaborator_list_add_remove(keep):
+    before = json.loads(cli.list_note_collaborators("n1"))
+    assert before == []
+
+    data = json.loads(cli.add_note_collaborator("n1", "user@example.com"))
+    assert "user@example.com" in data["collaborators"]
+    after = json.loads(cli.remove_note_collaborator("n1", "user@example.com"))
+    assert "user@example.com" not in after["collaborators"]
+
+
+def test_list_note_media(keep):
+    media = json.loads(cli.list_note_media("n1"))
+    assert media[0]["media_link"].startswith("https://media/")
+
+
+def test_modification_guard_blocks_when_unlabeled(keep, monkeypatch):
+    keep.notes["n1"].labels = DummyLabels()
+    monkeypatch.setattr(cli, "can_modify_note", lambda _: False)
+    with pytest.raises(ValueError, match="cannot be modified"):
+        cli.update_note("n1", title="x")
+
+
+def test_main_runs_stdio_transport(monkeypatch):
+    captured = {}
+
+    def fake_run(*, transport):
+        captured["transport"] = transport
+
+    monkeypatch.setattr(cli.mcp, "run", fake_run)
+    cli.main()
+    assert captured["transport"] == "stdio"

--- a/tests/test_keep_api.py
+++ b/tests/test_keep_api.py
@@ -1,0 +1,91 @@
+from types import SimpleNamespace
+
+from server.keep_api import can_modify_note, serialize_note
+
+
+class DummyLabels:
+    def __init__(self, labels):
+        self._labels = labels
+
+    def all(self):
+        return self._labels
+
+
+class DummyCollaborators:
+    def __init__(self, emails):
+        self._emails = emails
+
+    def all(self):
+        return self._emails
+
+
+class DummyBlobType:
+    def __init__(self, value):
+        self.value = value
+
+
+class DummyBlobNode:
+    def __init__(self, blob_id, blob_type):
+        self.id = blob_id
+        self.blob = SimpleNamespace(type=DummyBlobType(blob_type))
+
+
+class DummyNote:
+    def __init__(self):
+        self.id = "n1"
+        self.title = "title"
+        self.text = "text"
+        self.type = SimpleNamespace(value="NOTE")
+        self.pinned = False
+        self.archived = False
+        self.trashed = False
+        self.color = SimpleNamespace(value="white")
+        self.labels = DummyLabels([SimpleNamespace(id="l1", name="keep-mcp")])
+        self.collaborators = DummyCollaborators(["alice@example.com"])
+        self.blobs = [DummyBlobNode("b1", "IMAGE")]
+
+
+class DummyListNote(DummyNote):
+    def __init__(self):
+        super().__init__()
+        self.items = [
+            SimpleNamespace(
+                id="i1",
+                text="item",
+                checked=False,
+                parent_item=None,
+            )
+        ]
+
+
+def test_serialize_note_for_note_type():
+    data = serialize_note(DummyNote())
+    assert data["id"] == "n1"
+    assert data["labels"][0]["name"] == "keep-mcp"
+    assert data["collaborators"] == ["alice@example.com"]
+    assert data["media"][0]["type"] == "IMAGE"
+    assert "items" not in data
+
+
+def test_serialize_note_for_list_type():
+    data = serialize_note(DummyListNote())
+    assert data["items"][0]["id"] == "i1"
+
+
+def test_can_modify_note_respects_label(monkeypatch):
+    monkeypatch.delenv("UNSAFE_MODE", raising=False)
+    assert can_modify_note(DummyNote()) is True
+
+
+def test_can_modify_note_respects_unsafe_mode(monkeypatch):
+    monkeypatch.setenv("UNSAFE_MODE", "true")
+    note = DummyNote()
+    note.labels = DummyLabels([])
+    assert can_modify_note(note) is True
+
+
+def test_can_modify_note_false_without_label_or_unsafe(monkeypatch):
+    monkeypatch.delenv("UNSAFE_MODE", raising=False)
+    note = DummyNote()
+    note.labels = DummyLabels([])
+    assert can_modify_note(note) is False

--- a/tests/test_keep_client.py
+++ b/tests/test_keep_client.py
@@ -1,0 +1,41 @@
+from server import keep_api
+
+
+class DummyKeep:
+    def __init__(self):
+        self.auth_calls = []
+
+    def authenticate(self, email, token):
+        self.auth_calls.append((email, token))
+
+
+def test_get_client_authenticates_and_caches(monkeypatch):
+    keep_api._keep_client = None
+    created = DummyKeep()
+
+    monkeypatch.setattr(keep_api, "load_dotenv", lambda: None)
+    monkeypatch.setattr(keep_api.os, "getenv", lambda key: {
+        "GOOGLE_EMAIL": "user@example.com",
+        "GOOGLE_MASTER_TOKEN": "token",
+    }.get(key))
+    monkeypatch.setattr(keep_api.gkeepapi, "Keep", lambda: created)
+
+    first = keep_api.get_client()
+    second = keep_api.get_client()
+
+    assert first is created
+    assert second is created
+    assert created.auth_calls == [("user@example.com", "token")]
+
+
+def test_get_client_raises_when_missing_credentials(monkeypatch):
+    keep_api._keep_client = None
+    monkeypatch.setattr(keep_api, "load_dotenv", lambda: None)
+    monkeypatch.setattr(keep_api.os, "getenv", lambda _key: None)
+
+    try:
+        keep_api.get_client()
+    except ValueError as exc:
+        assert "Missing Google Keep credentials" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for missing credentials")

--- a/tests/test_main_module.py
+++ b/tests/test_main_module.py
@@ -1,0 +1,14 @@
+import runpy
+
+
+def test_main_module_calls_cli_main(monkeypatch):
+    called = {"value": False}
+
+    def fake_main():
+        called["value"] = True
+
+    import server.cli
+
+    monkeypatch.setattr(server.cli, "main", fake_main)
+    runpy.run_module("server.__main__", run_name="__main__")
+    assert called["value"] is True


### PR DESCRIPTION
### Motivation
- Close the coverage gap reported for `src/server` by exercising previously-uncovered CLI and client bootstrap execution paths. 
- Validate defensive guards and serialization behavior around lists, labels, collaborators, and media. 
- Ensure CI will catch regressions by adding a coverage-enabled workflow and a developer smoke path for manual verification.

### Description
- Expand `src/server/cli.py` with helper guards (`_get_note_or_raise`, `_ensure_modifiable`) and add/check many MCP tools for lists, list-item CRUD, label operations, collaborators, media listing, state transitions, and color validation. 
- Extend `src/server/keep_api.py` with `serialize_label`, `serialize_list_item`, richer `serialize_note` output (labels, collaborators, items, media) and leave `get_client()` caching/auth bootstrap in place. 
- Add comprehensive unit tests in `tests/` (`test_cli.py`, `test_keep_api.py`, `test_keep_client.py`, `test_main_module.py`) and a `tests/conftest.py` shim to load the `src` package path. 
- Add CI workflow at `.github/workflows/ci.yml`, a manual `scripts/smoke_test.py`, and README updates describing testing, smoke test usage, and CI checks.

### Testing
- Ran `ruff check .` locally and it completed successfully. 
- Ran `pytest -q` locally and all tests passed (`28 passed`). 
- Attempted local coverage run `pytest -q --cov=src/server --cov-report=term-missing --cov-fail-under=70`, but the local environment lacks the `pytest-cov` plugin so the `--cov` flags failed; CI workflow is configured to run coverage with `pytest-cov`. 
- The added unit tests exercise the new/previously-missed branches for CLI tools and `get_client()` bootstrap and cache behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69987e4929048322afef7da751af9ee7)