### PR TITLE
Add error handling for Google Keep API authentication

### DIFF
--- a/src/server/keep_api.py
+++ b/src/server/keep_api.py
@@ -1,5 +1,6 @@
 import gkeepapi
 import os
+import requests
 from dotenv import load_dotenv
 
 _keep_client = None
@@ -31,7 +32,21 @@ def get_client():
     keep = gkeepapi.Keep()
     
     # Authenticate
-    keep.authenticate(email, master_token)
+    try:
+        keep.authenticate(email, master_token)
+    except requests.exceptions.JSONDecodeError as exc:
+        raise RuntimeError(
+            "Google Keep API returned a non-JSON response during authentication. "
+            "This usually means the unofficial Keep API (notes/v1) is inaccessible "
+            "from this environment (HTTP 403/4xx). "
+            "Check that your GOOGLE_MASTER_TOKEN is valid and that the Keep API "
+            "is reachable from this network."
+        ) from exc
+    except gkeepapi.exception.LoginException as exc:
+        raise RuntimeError(
+            f"Google Keep login failed: {exc}. "
+            "Verify that GOOGLE_EMAIL and GOOGLE_MASTER_TOKEN are correct."
+        ) from exc
     
     # Store the client for reuse
     _keep_client = keep


### PR DESCRIPTION
## Summary
Enhanced error handling in the Google Keep API client initialization to provide clearer, more actionable error messages when authentication fails.

## Key Changes
- Added `requests` import to handle HTTP-related exceptions
- Wrapped `keep.authenticate()` call in try-except block to catch and handle two specific exception types:
  - `requests.exceptions.JSONDecodeError`: Occurs when the Keep API returns non-JSON responses (typically due to HTTP 403/4xx errors indicating the API is inaccessible)
  - `gkeepapi.exception.LoginException`: Occurs when authentication credentials are invalid
- Both exceptions are converted to `RuntimeError` with descriptive messages that guide users toward resolution:
  - For JSON decode errors: suggests checking token validity and network accessibility
  - For login failures: suggests verifying email and master token credentials

## Implementation Details
- Error messages are user-friendly and include context about what likely went wrong
- Original exceptions are chained using `from exc` to preserve the full error traceback for debugging
- This prevents cryptic low-level exceptions from reaching users and improves the debugging experience

https://claude.ai/code/session_01JXq18PfxE6EP3pwoZiAShT