### PR TITLE
Claude/review keep api z k79q

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e . pytest pytest-cov ruff python-dotenv
+
+      - name: Lint
+        run: ruff check .
+
+      - name: Run tests with coverage
+        run: pytest -q --cov=src/server --cov-report=term-missing --cov-fail-under=70
+
+      - name: Bytecode sanity
+        run: python -m compileall src

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,8 @@ Thumbs.db
 uv.lock
 API_DOCS.md
 progress
+
+# Test artifacts
+.coverage
+htmlcov/
+.pytest_cache/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+SHELL := /bin/bash
+
+UV ?= uv
+UV_CACHE_DIR ?= /tmp/uv-cache
+PYTHON_VERSION ?= 3.11
+VENV_PYTHON := .venv/bin/python
+UV_RUN := UV_CACHE_DIR=$(UV_CACHE_DIR) $(UV) run --no-sync --python $(VENV_PYTHON)
+DEV_TOOLS := pytest ruff
+
+.PHONY: install start test smoke lint check-venv
+
+install:
+	UV_CACHE_DIR=$(UV_CACHE_DIR) $(UV) venv --python $(PYTHON_VERSION) .venv
+	UV_CACHE_DIR=$(UV_CACHE_DIR) $(UV) pip install --python $(VENV_PYTHON) -e .
+	UV_CACHE_DIR=$(UV_CACHE_DIR) $(UV) pip install --python $(VENV_PYTHON) $(DEV_TOOLS)
+
+check-venv:
+	@test -x $(VENV_PYTHON) || (echo "Missing .venv. Run 'make install' first."; exit 1)
+
+start: check-venv
+	$(UV_RUN) -m server
+
+test: check-venv
+	$(UV_RUN) pytest -q
+
+smoke: check-venv
+	@test -n "$(GOOGLE_EMAIL)" || (echo "GOOGLE_EMAIL is required"; exit 1)
+	@test -n "$(GOOGLE_MASTER_TOKEN)" || (echo "GOOGLE_MASTER_TOKEN is required"; exit 1)
+	$(UV_RUN) scripts/smoke_test.py
+
+lint: check-venv
+	$(UV_RUN) ruff check .

--- a/README.md
+++ b/README.md
@@ -32,10 +32,35 @@ Check https://gkeepapi.readthedocs.io/en/latest/#obtaining-a-master-token and ht
 
 ## Features
 
-* `find`: Search for notes based on a query string
+### Query and read tools
+* `find`: Search notes with optional filters for labels, colors, pinned, archived, and trashed
+* `get_note`: Get a single note by ID
+
+### Creation and update tools
 * `create_note`: Create a new note with title and text (automatically adds keep-mcp label)
+* `create_list`: Create a checklist note
 * `update_note`: Update a note's title and text
+* `add_list_item`: Add an item to a checklist note
+* `update_list_item`: Update checklist item text and checked state
+* `delete_list_item`: Delete a checklist item
+
+### Note state tools
+* `pin_note`: Pin or unpin a note
+* `archive_note`: Archive or unarchive a note
+* `trash_note`: Move a note to trash
+* `restore_note`: Restore a trashed/deleted note
 * `delete_note`: Mark a note for deletion
+
+### Labels, collaborators, and media tools
+* `list_labels`: List labels
+* `create_label`: Create a label
+* `delete_label`: Delete a label
+* `add_label_to_note`: Add a label to a note
+* `remove_label_from_note`: Remove a label from a note
+* `list_note_collaborators`: List collaborator emails for a note
+* `add_note_collaborator`: Add a collaborator email to a note
+* `remove_note_collaborator`: Remove a collaborator email from a note
+* `list_note_media`: List media blobs for a note (with media links)
 
 By default, all destructive and modification operations are restricted to notes that have were created by the MCP server (i.e. have the keep-mcp label). Set `UNSAFE_MODE` to `true` to bypass this restriction.
 
@@ -45,6 +70,47 @@ By default, all destructive and modification operations are restricted to notes 
   "UNSAFE_MODE": "true"
 }
 ```
+
+## Testing
+
+### Unit tests (default)
+The project includes a lightweight unit test suite under `tests/`.
+
+It validates:
+* note serialization shape for note and list objects (including labels, collaborators, media, and list items)
+* modification safety behavior (`keep-mcp` label requirement and `UNSAFE_MODE=true` override)
+* MCP tool behavior in `src/server/cli.py` using mocked Keep client objects (tool happy paths and key error paths)
+
+Run locally:
+
+```bash
+pytest -q
+```
+
+### Smoke test against a real Keep account
+For additional confidence, run a basic lifecycle smoke test against a dedicated test account:
+
+```bash
+GOOGLE_EMAIL="you@example.com" \
+GOOGLE_MASTER_TOKEN="..." \
+python scripts/smoke_test.py
+```
+
+What it does:
+* create note
+* update note
+* pin/unpin
+* archive/unarchive
+* trash/restore
+* delete
+
+This script is intended for manual verification and is not run in CI.
+
+### CI checks
+GitHub Actions runs on every pull request and executes:
+* lint (`ruff check .`)
+* unit tests with coverage (`pytest -q --cov=src/server --cov-report=term-missing --cov-fail-under=70`)
+* bytecode sanity (`python -m compileall src`)
 
 ## Publishing
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,33 @@ By default, all destructive and modification operations are restricted to notes 
 }
 ```
 
+## Local development (uv + make)
+
+If you prefer a JS-style workflow (`npm i`, `npm start`), use the included `Makefile`:
+
+```bash
+make install   # like npm i
+make start     # like npm start
+make test
+make lint
+```
+
+Run the real-account smoke test with credentials:
+
+```bash
+GOOGLE_EMAIL="you@example.com" \
+GOOGLE_MASTER_TOKEN="..." \
+make smoke
+```
+
+Equivalent direct `uv` commands (without `make`):
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache uv venv --python 3.11 .venv
+UV_CACHE_DIR=/tmp/uv-cache uv pip install --python .venv/bin/python -e .
+UV_CACHE_DIR=/tmp/uv-cache uv run --no-sync --python .venv/bin/python -m server
+```
+
 ## Testing
 
 ### Unit tests (default)
@@ -85,7 +112,7 @@ It validates:
 Run locally:
 
 ```bash
-pytest -q
+make test
 ```
 
 ### Smoke test against a real Keep account
@@ -94,7 +121,7 @@ For additional confidence, run a basic lifecycle smoke test against a dedicated 
 ```bash
 GOOGLE_EMAIL="you@example.com" \
 GOOGLE_MASTER_TOKEN="..." \
-python scripts/smoke_test.py
+make smoke
 ```
 
 What it does:
@@ -126,6 +153,69 @@ To publish a new version to PyPI:
    ```bash
    pipx run twine upload --repository pypi dist/*
    ```
+
+## Run locally with MCP clients
+
+This is useful when you want a client to run this server from your local checkout instead of PyPI.
+
+1. Create a local virtualenv and install in editable mode:
+
+```bash
+cd /ABSOLUTE/PATH/TO/keep-mcp
+make install
+```
+
+2. Add the server to your MCP client config.
+
+### `config.toml` clients (Codex, Goose, etc.)
+
+```toml
+[mcp_servers.keep_mcp]
+command = "make"
+args = ["-C", "/ABSOLUTE/PATH/TO/keep-mcp", "start"]
+
+[mcp_servers.keep_mcp.env]
+GOOGLE_EMAIL = "you@example.com"
+GOOGLE_MASTER_TOKEN = "your-master-token"
+UNSAFE_MODE = "false"
+```
+
+### JSON `mcpServers` clients (Claude Desktop, Cursor, Cline, etc.)
+
+```json
+{
+  "mcpServers": {
+    "keep-mcp-local": {
+      "command": "make",
+      "args": ["-C", "/ABSOLUTE/PATH/TO/keep-mcp", "start"],
+      "env": {
+        "GOOGLE_EMAIL": "you@example.com",
+        "GOOGLE_MASTER_TOKEN": "your-master-token",
+        "UNSAFE_MODE": "false"
+      }
+    }
+  }
+}
+```
+
+Alternative (without `make`):
+
+```toml
+[mcp_servers.keep_mcp]
+command = "uv"
+args = [
+  "--directory", "/ABSOLUTE/PATH/TO/keep-mcp",
+  "run", "--no-sync", "--python", ".venv/bin/python",
+  "-m", "server"
+]
+```
+
+Notes:
+* Run `make install` once before starting from an MCP client.
+* Only the repo root path is required (no absolute `/.venv/bin/python` path).
+* Ensure `make` and `uv` are in your `PATH`.
+* Restart your MCP client after updating config files.
+* `UNSAFE_MODE` is optional; keep it `"false"` unless you explicitly want to modify non-`keep-mcp` notes.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Check https://gkeepapi.readthedocs.io/en/latest/#obtaining-a-master-token and ht
 * `delete_list_item`: Delete a checklist item
 
 ### Note state tools
+* `set_note_color`: Set a note color (valid values: DEFAULT, RED, ORANGE, YELLOW, GREEN, TEAL, BLUE, CERULEAN, PURPLE, PINK, BROWN, GRAY)
 * `pin_note`: Pin or unpin a note
 * `archive_note`: Archive or unarchive a note
 * `trash_note`: Move a note to trash

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -1,0 +1,57 @@
+"""Basic real-account smoke test for keep-mcp server logic.
+
+Usage:
+  GOOGLE_EMAIL=... GOOGLE_MASTER_TOKEN=... python scripts/smoke_test.py
+
+This script performs a minimal lifecycle against Google Keep:
+- create note
+- update note
+- pin/unpin
+- archive/unarchive
+- trash/restore
+- delete
+
+It is intended for manual verification, not CI.
+"""
+
+import json
+import os
+
+from server import cli
+
+
+def main() -> None:
+    if not os.getenv("GOOGLE_EMAIL") or not os.getenv("GOOGLE_MASTER_TOKEN"):
+        raise SystemExit("Set GOOGLE_EMAIL and GOOGLE_MASTER_TOKEN before running smoke test")
+
+    print("Creating note...")
+    created = json.loads(cli.create_note(title="keep-mcp smoke", text="hello"))
+    note_id = created["id"]
+    print("Created:", note_id)
+
+    print("Updating note...")
+    updated = json.loads(cli.update_note(note_id, title="keep-mcp smoke updated", text="world"))
+    assert updated["title"] == "keep-mcp smoke updated"
+
+    print("Pin/unpin...")
+    assert json.loads(cli.pin_note(note_id, True))["pinned"] is True
+    assert json.loads(cli.pin_note(note_id, False))["pinned"] is False
+
+    print("Archive/unarchive...")
+    assert json.loads(cli.archive_note(note_id, True))["archived"] is True
+    assert json.loads(cli.archive_note(note_id, False))["archived"] is False
+
+    print("Trash/restore...")
+    assert json.loads(cli.trash_note(note_id))["trashed"] is True
+    restored = json.loads(cli.restore_note(note_id))
+    assert restored["trashed"] is False
+
+    print("Deleting note...")
+    delete_msg = json.loads(cli.delete_note(note_id))
+    assert "marked for deletion" in delete_msg["message"]
+
+    print("Smoke test finished successfully")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -3,13 +3,16 @@
 Usage:
   GOOGLE_EMAIL=... GOOGLE_MASTER_TOKEN=... python scripts/smoke_test.py
 
-This script performs a minimal lifecycle against Google Keep:
+This script performs a lifecycle against Google Keep:
 - create note
 - update note
+- set color
 - pin/unpin
 - archive/unarchive
 - trash/restore
 - delete
+- create list + add/update/delete list items
+- label CRUD and association
 
 It is intended for manual verification, not CI.
 """
@@ -24,6 +27,7 @@ def main() -> None:
     if not os.getenv("GOOGLE_EMAIL") or not os.getenv("GOOGLE_MASTER_TOKEN"):
         raise SystemExit("Set GOOGLE_EMAIL and GOOGLE_MASTER_TOKEN before running smoke test")
 
+    # --- Note lifecycle ---
     print("Creating note...")
     created = json.loads(cli.create_note(title="keep-mcp smoke", text="hello"))
     note_id = created["id"]
@@ -32,6 +36,12 @@ def main() -> None:
     print("Updating note...")
     updated = json.loads(cli.update_note(note_id, title="keep-mcp smoke updated", text="world"))
     assert updated["title"] == "keep-mcp smoke updated"
+
+    print("Setting color...")
+    colored = json.loads(cli.set_note_color(note_id, "RED"))
+    assert colored["color"] == "RED"
+    # Reset to default
+    json.loads(cli.set_note_color(note_id, "DEFAULT"))
 
     print("Pin/unpin...")
     assert json.loads(cli.pin_note(note_id, True))["pinned"] is True
@@ -49,6 +59,64 @@ def main() -> None:
     print("Deleting note...")
     delete_msg = json.loads(cli.delete_note(note_id))
     assert "marked for deletion" in delete_msg["message"]
+
+    # --- Checklist lifecycle ---
+    print("Creating list...")
+    lst = json.loads(cli.create_list("keep-mcp smoke list", items=[{"text": "item1", "checked": False}]))
+    list_id = lst["id"]
+    print("List created:", list_id)
+    assert lst["items"][0]["text"] == "item1"
+
+    print("Adding list item...")
+    added = json.loads(cli.add_list_item(list_id, "item2", checked=False))
+    item_id = added["item_id"]
+
+    print("Updating list item...")
+    updated_list = json.loads(cli.update_list_item(list_id, item_id, text="item2 edited", checked=True))
+    edited = next(i for i in updated_list["items"] if i["id"] == item_id)
+    assert edited["text"] == "item2 edited"
+    assert edited["checked"] is True
+
+    print("Deleting list item...")
+    del_item = json.loads(cli.delete_list_item(list_id, item_id))
+    assert "marked for deletion" in del_item["message"]
+
+    print("Deleting list note...")
+    json.loads(cli.delete_note(list_id))
+
+    # --- Label lifecycle ---
+    print("Creating label...")
+    label = json.loads(cli.create_label("keep-mcp-smoke-label"))
+    label_id = label["id"]
+    print("Label created:", label_id)
+
+    print("Listing labels (should include new label)...")
+    labels = json.loads(cli.list_labels())
+    assert any(lb["id"] == label_id for lb in labels)
+
+    print("Creating note for label association...")
+    note_for_label = json.loads(cli.create_note(title="label test"))
+    nfl_id = note_for_label["id"]
+
+    print("Adding label to note...")
+    labeled = json.loads(cli.add_label_to_note(nfl_id, label_id))
+    assert any(lb["id"] == label_id for lb in labeled["labels"])
+
+    print("Removing label from note...")
+    unlabeled = json.loads(cli.remove_label_from_note(nfl_id, label_id))
+    assert all(lb["id"] != label_id for lb in unlabeled["labels"])
+
+    print("Deleting label...")
+    del_label = json.loads(cli.delete_label(label_id))
+    assert "marked for deletion" in del_label["message"]
+
+    print("Cleaning up label test note...")
+    json.loads(cli.delete_note(nfl_id))
+
+    # --- find() ---
+    print("Testing find()...")
+    results = json.loads(cli.find(query="keep-mcp"))
+    assert isinstance(results, list)
 
     print("Smoke test finished successfully")
 

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -19,6 +19,10 @@ It is intended for manual verification, not CI.
 
 import json
 import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from server import cli
 

--- a/src/server/cli.py
+++ b/src/server/cli.py
@@ -30,6 +30,20 @@ def _ensure_modifiable(note):
         )
 
 
+def _normalize_colors(colors: list[str] | None):
+    if colors is None:
+        return None
+
+    normalized_colors = []
+    for color in colors:
+        try:
+            normalized_colors.append(gkeepapi.node.ColorValue(color))
+        except ValueError as exc:
+            raise ValueError(f"Invalid color '{color}'") from exc
+
+    return normalized_colors
+
+
 @mcp.tool()
 def find(
     query: str = "",
@@ -41,10 +55,11 @@ def find(
 ) -> str:
     """Find notes using text and optional filters."""
     keep = get_client()
+    normalized_colors = _normalize_colors(colors)
     notes = keep.find(
         query=query,
         labels=labels,
-        colors=colors,
+        colors=normalized_colors,
         pinned=pinned,
         archived=archived,
         trashed=trashed,

--- a/src/server/cli.py
+++ b/src/server/cli.py
@@ -9,7 +9,7 @@ from typing import Any
 import gkeepapi
 from mcp.server.fastmcp import FastMCP
 
-from .keep_api import KEEP_MCP_LABEL, can_modify_note, get_client, is_unsafe_mode, serialize_label, serialize_note
+from .keep_api import KEEP_MCP_LABEL, can_modify_note, get_client, has_keep_mcp_label, is_unsafe_mode, serialize_label, serialize_note
 
 mcp = FastMCP("keep")
 
@@ -280,11 +280,22 @@ def delete_label(label_id: str) -> str:
     label = keep.getLabel(label_id)
     if not label:
         raise ValueError(f"Label with ID {label_id} not found")
-    if label.name == KEEP_MCP_LABEL and not is_unsafe_mode():
-        raise ValueError(
-            f"Cannot delete the '{KEEP_MCP_LABEL}' label in safe mode: all notes managed "
-            "by this server would become permanently unmodifiable. Set UNSAFE_MODE=true to override."
-        )
+    if not is_unsafe_mode():
+        if label.name == KEEP_MCP_LABEL:
+            raise ValueError(
+                f"Cannot delete the '{KEEP_MCP_LABEL}' label in safe mode: all notes managed "
+                "by this server would become permanently unmodifiable. Set UNSAFE_MODE=true to override."
+            )
+        unmanaged = [
+            n for n in keep.all()
+            if any(lb.id == label_id for lb in n.labels.all()) and not has_keep_mcp_label(n)
+        ]
+        if unmanaged:
+            raise ValueError(
+                f"Cannot delete label '{label.name}' in safe mode: it is attached to "
+                f"{len(unmanaged)} unmanaged note(s). Deleting it would silently modify "
+                "those notes. Set UNSAFE_MODE=true to override."
+            )
     keep.deleteLabel(label_id)
     keep.sync()
     return json.dumps({"message": f"Label {label_id} marked for deletion"})

--- a/src/server/cli.py
+++ b/src/server/cli.py
@@ -4,118 +4,349 @@ Provides tools for interacting with Google Keep notes through MCP.
 """
 
 import json
+from typing import Any
+
+import gkeepapi
 from mcp.server.fastmcp import FastMCP
-from .keep_api import get_client, serialize_note, can_modify_note
+
+from .keep_api import can_modify_note, get_client, serialize_label, serialize_note
 
 mcp = FastMCP("keep")
 
-@mcp.tool()
-def find(query="") -> str:
-    """
-    Find notes based on a search query.
-    
-    Args:
-        query (str, optional): A string to match against the title and text
-        
-    Returns:
-        str: JSON string containing the matching notes with their id, title, text, pinned status, color and labels
-    """
+
+def _get_note_or_raise(note_id: str):
     keep = get_client()
-    notes = keep.find(query=query, archived=False, trashed=False)
-    
+    note = keep.get(note_id)
+    if not note:
+        raise ValueError(f"Note with ID {note_id} not found")
+    return keep, note
+
+
+def _ensure_modifiable(note):
+    if not can_modify_note(note):
+        raise ValueError(
+            f"Note with ID {note.id} cannot be modified "
+            "(missing keep-mcp label and UNSAFE_MODE is not enabled)"
+        )
+
+
+@mcp.tool()
+def find(
+    query: str = "",
+    labels: list[str] | None = None,
+    colors: list[str] | None = None,
+    pinned: bool | None = None,
+    archived: bool | None = False,
+    trashed: bool = False,
+) -> str:
+    """Find notes using text and optional filters."""
+    keep = get_client()
+    notes = keep.find(
+        query=query,
+        labels=labels,
+        colors=colors,
+        pinned=pinned,
+        archived=archived,
+        trashed=trashed,
+    )
+
     notes_data = [serialize_note(note) for note in notes]
     return json.dumps(notes_data)
 
-@mcp.tool()
-def create_note(title: str = None, text: str = None) -> str:
-    """
-    Create a new note with title and text.
-    
-    Args:
-        title (str, optional): The title of the note
-        text (str, optional): The content of the note
-        
-    Returns:
-        str: JSON string containing the created note's data
-    """
-    keep = get_client()
-    note = keep.createNote(title=title, text=text)
-    
-    # Get or create the keep-mcp label
-    label = keep.findLabel('keep-mcp')
-    if not label:
-        label = keep.createLabel('keep-mcp')
-    
-    # Add the label to the note
-    note.labels.add(label)
-    keep.sync()  # Ensure the note is created and labeled on the server
-    
-    return json.dumps(serialize_note(note))
 
 @mcp.tool()
-def update_note(note_id: str, title: str = None, text: str = None) -> str:
+def get_note(note_id: str) -> str:
+    """Get a note by ID."""
+    _, note = _get_note_or_raise(note_id)
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def create_note(title: str | None = None, text: str | None = None) -> str:
+    """Create a new note with title and text."""
+    keep = get_client()
+    note = keep.createNote(title=title, text=text)
+
+    label = keep.findLabel("keep-mcp")
+    if not label:
+        label = keep.createLabel("keep-mcp")
+
+    note.labels.add(label)
+    keep.sync()
+
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def create_list(title: str | None = None, items: list[dict[str, Any]] | None = None) -> str:
     """
-    Update a note's properties.
-    
-    Args:
-        note_id (str): The ID of the note to update
-        title (str, optional): New title for the note
-        text (str, optional): New text content for the note
-        
-    Returns:
-        str: JSON string containing the updated note's data
-        
-    Raises:
-        ValueError: If the note doesn't exist or cannot be modified
+    Create a new checklist note.
+
+    items should be objects like: {"text": "task", "checked": false}
     """
     keep = get_client()
-    note = keep.get(note_id)
-    
-    if not note:
-        raise ValueError(f"Note with ID {note_id} not found")
-    
-    if not can_modify_note(note):
-        raise ValueError(f"Note with ID {note_id} cannot be modified (missing keep-mcp label and UNSAFE_MODE is not enabled)")
-    
+    formatted_items = None
+    if items:
+        formatted_items = [
+            (item.get("text", ""), bool(item.get("checked", False))) for item in items
+        ]
+
+    note = keep.createList(title=title, items=formatted_items)
+
+    label = keep.findLabel("keep-mcp")
+    if not label:
+        label = keep.createLabel("keep-mcp")
+    note.labels.add(label)
+
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def add_list_item(note_id: str, text: str, checked: bool = False) -> str:
+    """Add an item to a checklist note."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    if not isinstance(note, gkeepapi.node.List):
+        raise ValueError(f"Note with ID {note_id} is not a list")
+
+    item = note.add(text=text, checked=checked)
+    keep.sync()
+    return json.dumps({"note_id": note.id, "item_id": item.id})
+
+
+@mcp.tool()
+def update_list_item(note_id: str, item_id: str, text: str | None = None, checked: bool | None = None) -> str:
+    """Update checklist item text and/or checked state."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    if not isinstance(note, gkeepapi.node.List):
+        raise ValueError(f"Note with ID {note_id} is not a list")
+
+    item = note.get(item_id)
+    if not item:
+        raise ValueError(f"List item with ID {item_id} not found")
+
+    if text is not None:
+        item.text = text
+    if checked is not None:
+        item.checked = checked
+
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def delete_list_item(note_id: str, item_id: str) -> str:
+    """Delete a checklist item."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    if not isinstance(note, gkeepapi.node.List):
+        raise ValueError(f"Note with ID {note_id} is not a list")
+
+    item = note.get(item_id)
+    if not item:
+        raise ValueError(f"List item with ID {item_id} not found")
+
+    item.delete()
+    keep.sync()
+    return json.dumps({"message": f"List item {item_id} marked for deletion"})
+
+
+@mcp.tool()
+def update_note(note_id: str, title: str | None = None, text: str | None = None) -> str:
+    """Update a note's properties."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
     if title is not None:
         note.title = title
     if text is not None:
         note.text = text
-    
-    keep.sync()  # Ensure changes are saved to the server
+
+    keep.sync()
     return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def set_note_color(note_id: str, color: str) -> str:
+    """Set a note color (e.g. white, red, orange, yellow, green, teal, blue, darkblue, purple, pink, brown, gray)."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    try:
+        note.color = gkeepapi.node.ColorValue(color)
+    except ValueError as exc:
+        raise ValueError(f"Invalid color '{color}'") from exc
+
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def pin_note(note_id: str, pinned: bool = True) -> str:
+    """Pin or unpin a note."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    note.pinned = pinned
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def archive_note(note_id: str, archived: bool = True) -> str:
+    """Archive or unarchive a note."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    note.archived = archived
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def trash_note(note_id: str) -> str:
+    """Move a note to trash."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    note.trash()
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def restore_note(note_id: str) -> str:
+    """Restore a trashed/deleted note."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    note.untrash()
+    note.undelete()
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
 
 @mcp.tool()
 def delete_note(note_id: str) -> str:
-    """
-    Delete a note (mark for deletion).
-    
-    Args:
-        note_id (str): The ID of the note to delete
-        
-    Returns:
-        str: Success message
-        
-    Raises:
-        ValueError: If the note doesn't exist or cannot be modified
-    """
-    keep = get_client()
-    note = keep.get(note_id)
-    
-    if not note:
-        raise ValueError(f"Note with ID {note_id} not found")
-    
-    if not can_modify_note(note):
-        raise ValueError(f"Note with ID {note_id} cannot be modified (missing keep-mcp label and UNSAFE_MODE is not enabled)")
-    
+    """Delete a note (mark for deletion)."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
     note.delete()
-    keep.sync()  # Ensure deletion is saved to the server
+    keep.sync()
     return json.dumps({"message": f"Note {note_id} marked for deletion"})
 
+
+@mcp.tool()
+def list_labels() -> str:
+    """List all labels."""
+    keep = get_client()
+    return json.dumps([serialize_label(label) for label in keep.labels()])
+
+
+@mcp.tool()
+def create_label(name: str) -> str:
+    """Create a label."""
+    keep = get_client()
+    label = keep.createLabel(name)
+    keep.sync()
+    return json.dumps(serialize_label(label))
+
+
+@mcp.tool()
+def delete_label(label_id: str) -> str:
+    """Delete a label by ID."""
+    keep = get_client()
+    keep.deleteLabel(label_id)
+    keep.sync()
+    return json.dumps({"message": f"Label {label_id} marked for deletion"})
+
+
+@mcp.tool()
+def add_label_to_note(note_id: str, label_id: str) -> str:
+    """Add a label to a note."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    label = keep.getLabel(label_id)
+    if not label:
+        raise ValueError(f"Label with ID {label_id} not found")
+
+    note.labels.add(label)
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def remove_label_from_note(note_id: str, label_id: str) -> str:
+    """Remove a label from a note."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    label = keep.getLabel(label_id)
+    if not label:
+        raise ValueError(f"Label with ID {label_id} not found")
+
+    note.labels.remove(label)
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def list_note_collaborators(note_id: str) -> str:
+    """List collaborator emails for a note."""
+    _, note = _get_note_or_raise(note_id)
+    return json.dumps(list(note.collaborators.all()))
+
+
+@mcp.tool()
+def add_note_collaborator(note_id: str, email: str) -> str:
+    """Add a collaborator email to a note."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    note.collaborators.add(email)
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def remove_note_collaborator(note_id: str, email: str) -> str:
+    """Remove a collaborator email from a note."""
+    keep, note = _get_note_or_raise(note_id)
+    _ensure_modifiable(note)
+
+    note.collaborators.remove(email)
+    keep.sync()
+    return json.dumps(serialize_note(note))
+
+
+@mcp.tool()
+def list_note_media(note_id: str) -> str:
+    """List note media blobs and direct media links when available."""
+    keep, note = _get_note_or_raise(note_id)
+
+    media = []
+    for blob in note.blobs:
+        media.append(
+            {
+                "blob_id": blob.id,
+                "type": blob.blob.type.value if blob.blob and blob.blob.type else None,
+                "media_link": keep.getMediaLink(blob),
+            }
+        )
+
+    return json.dumps(media)
+
+
 def main():
-    mcp.run(transport='stdio')
+    mcp.run(transport="stdio")
 
 
 if __name__ == "__main__":
     main()
-    

--- a/src/server/cli.py
+++ b/src/server/cli.py
@@ -9,7 +9,7 @@ from typing import Any
 import gkeepapi
 from mcp.server.fastmcp import FastMCP
 
-from .keep_api import can_modify_note, get_client, serialize_label, serialize_note
+from .keep_api import KEEP_MCP_LABEL, can_modify_note, get_client, is_unsafe_mode, serialize_label, serialize_note
 
 mcp = FastMCP("keep")
 
@@ -277,8 +277,14 @@ def create_label(name: str) -> str:
 def delete_label(label_id: str) -> str:
     """Delete a label by ID."""
     keep = get_client()
-    if not keep.getLabel(label_id):
+    label = keep.getLabel(label_id)
+    if not label:
         raise ValueError(f"Label with ID {label_id} not found")
+    if label.name == KEEP_MCP_LABEL and not is_unsafe_mode():
+        raise ValueError(
+            f"Cannot delete the '{KEEP_MCP_LABEL}' label in safe mode: all notes managed "
+            "by this server would become permanently unmodifiable. Set UNSAFE_MODE=true to override."
+        )
     keep.deleteLabel(label_id)
     keep.sync()
     return json.dumps({"message": f"Label {label_id} marked for deletion"})
@@ -308,6 +314,11 @@ def remove_label_from_note(note_id: str, label_id: str) -> str:
     label = keep.getLabel(label_id)
     if not label:
         raise ValueError(f"Label with ID {label_id} not found")
+    if label.name == KEEP_MCP_LABEL and not is_unsafe_mode():
+        raise ValueError(
+            f"Cannot remove the '{KEEP_MCP_LABEL}' label in safe mode: the note would "
+            "become permanently unmodifiable. Set UNSAFE_MODE=true to override."
+        )
 
     note.labels.remove(label)
     keep.sync()

--- a/src/server/cli.py
+++ b/src/server/cli.py
@@ -53,7 +53,7 @@ def find(
     archived: bool | None = False,
     trashed: bool = False,
 ) -> str:
-    """Find notes using text and optional filters."""
+    """Find notes using text and optional filters. labels should be label IDs. colors should be ColorValue strings (e.g. DEFAULT, RED, CERULEAN)."""
     keep = get_client()
     normalized_colors = _normalize_colors(colors)
     notes = keep.find(
@@ -188,7 +188,7 @@ def update_note(note_id: str, title: str | None = None, text: str | None = None)
 
 @mcp.tool()
 def set_note_color(note_id: str, color: str) -> str:
-    """Set a note color (e.g. white, red, orange, yellow, green, teal, blue, darkblue, purple, pink, brown, gray)."""
+    """Set a note color. Valid values: DEFAULT (white), RED, ORANGE, YELLOW, GREEN, TEAL, BLUE, CERULEAN (dark blue), PURPLE, PINK, BROWN, GRAY."""
     keep, note = _get_note_or_raise(note_id)
     _ensure_modifiable(note)
 
@@ -277,6 +277,8 @@ def create_label(name: str) -> str:
 def delete_label(label_id: str) -> str:
     """Delete a label by ID."""
     keep = get_client()
+    if not keep.getLabel(label_id):
+        raise ValueError(f"Label with ID {label_id} not found")
     keep.deleteLabel(label_id)
     keep.sync()
     return json.dumps({"message": f"Label {label_id} marked for deletion"})

--- a/src/server/keep_api.py
+++ b/src/server/keep_api.py
@@ -3,6 +3,8 @@ import os
 import requests
 from dotenv import load_dotenv
 
+KEEP_MCP_LABEL = "keep-mcp"
+
 _keep_client = None
 
 def get_client():
@@ -102,27 +104,31 @@ def serialize_note(note):
 
     return payload
 
+def is_unsafe_mode() -> bool:
+    return os.getenv('UNSAFE_MODE', '').lower() == 'true'
+
+
 def can_modify_note(note):
     """
     Check if a note can be modified based on label and environment settings.
-    
+
     Args:
         note: A Google Keep note object
-        
+
     Returns:
         bool: True if the note can be modified, False otherwise
     """
-    unsafe_mode = os.getenv('UNSAFE_MODE', '').lower() == 'true'
-    return unsafe_mode or has_keep_mcp_label(note)
+    return is_unsafe_mode() or has_keep_mcp_label(note)
+
 
 def has_keep_mcp_label(note):
     """
     Check if a note has the keep-mcp label.
-    
+
     Args:
         note: A Google Keep note object
-        
+
     Returns:
         bool: True if the note has the keep-mcp label, False otherwise
     """
-    return any(label.name == 'keep-mcp' for label in note.labels.all()) 
+    return any(label.name == KEEP_MCP_LABEL for label in note.labels.all())

--- a/src/server/keep_api.py
+++ b/src/server/keep_api.py
@@ -38,6 +38,19 @@ def get_client():
     
     return keep
 
+def serialize_label(label):
+    return {'id': label.id, 'name': label.name}
+
+
+def serialize_list_item(item):
+    return {
+        'id': item.id,
+        'text': item.text,
+        'checked': item.checked,
+        'parent_item_id': item.parent_item.id if item.parent_item else None,
+    }
+
+
 def serialize_note(note):
     """
     Serialize a Google Keep note into a dictionary.
@@ -48,14 +61,31 @@ def serialize_note(note):
     Returns:
         dict: A dictionary containing the note's id, title, text, pinned status, color and labels
     """
-    return {
+    payload = {
         'id': note.id,
         'title': note.title,
         'text': note.text,
+        'type': note.type.value,
         'pinned': note.pinned,
+        'archived': note.archived,
+        'trashed': note.trashed,
         'color': note.color.value if note.color else None,
-        'labels': [{'id': label.id, 'name': label.name} for label in note.labels.all()]
+        'labels': [serialize_label(label) for label in note.labels.all()],
+        'collaborators': list(note.collaborators.all()),
     }
+
+    if hasattr(note, 'items'):
+        payload['items'] = [serialize_list_item(item) for item in note.items]
+
+    payload['media'] = [
+        {
+            'blob_id': blob.id,
+            'type': blob.blob.type.value if blob.blob and blob.blob.type else None,
+        }
+        for blob in note.blobs
+    ]
+
+    return payload
 
 def can_modify_note(note):
     """

--- a/src/server/keep_api.py
+++ b/src/server/keep_api.py
@@ -1,5 +1,6 @@
 import gkeepapi
 import os
+import requests
 from dotenv import load_dotenv
 
 _keep_client = None
@@ -31,7 +32,21 @@ def get_client():
     keep = gkeepapi.Keep()
     
     # Authenticate
-    keep.authenticate(email, master_token)
+    try:
+        keep.authenticate(email, master_token)
+    except requests.exceptions.JSONDecodeError as exc:
+        raise RuntimeError(
+            "Google Keep API returned a non-JSON response during authentication. "
+            "This usually means the unofficial Keep API (notes/v1) is inaccessible "
+            "from this environment (HTTP 403/4xx). "
+            "Check that your GOOGLE_MASTER_TOKEN is valid and that the Keep API "
+            "is reachable from this network."
+        ) from exc
+    except gkeepapi.exception.LoginException as exc:
+        raise RuntimeError(
+            f"Google Keep login failed: {exc}. "
+            "Verify that GOOGLE_EMAIL and GOOGLE_MASTER_TOKEN are correct."
+        ) from exc
     
     # Store the client for reuse
     _keep_client = keep

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -200,7 +200,17 @@ def test_find_forwards_filters(keep):
     )
     assert keep.last_find_kwargs["query"] == "q"
     assert keep.last_find_kwargs["labels"] == ["l1"]
+    assert [color.value for color in keep.last_find_kwargs["colors"]] == ["red"]
     assert isinstance(result, list)
+
+
+def test_find_invalid_color_raises(keep, monkeypatch):
+    def bad_color(_):
+        raise ValueError("bad")
+
+    monkeypatch.setattr(cli.gkeepapi.node, "ColorValue", bad_color)
+    with pytest.raises(ValueError, match="Invalid color 'invalid'"):
+        cli.find(colors=["invalid"])
 
 
 def test_get_note(keep):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -204,6 +204,11 @@ def test_find_forwards_filters(keep):
     assert isinstance(result, list)
 
 
+def test_find_without_colors_passes_none(keep):
+    cli.find(query="q")
+    assert keep.last_find_kwargs["colors"] is None
+
+
 def test_find_invalid_color_raises(keep, monkeypatch):
     def bad_color(_):
         raise ValueError("bad")
@@ -237,6 +242,12 @@ def test_create_list_variants(keep):
         cli.create_list("list", items=[{"text": "a", "checked": True}])
     )
     assert data_with_items["items"][0]["checked"] is True
+
+
+def test_create_list_creates_label_when_missing(keep):
+    keep._labels = {}
+    data = json.loads(cli.create_list("list"))
+    assert data["labels"][0]["name"] == "keep-mcp"
 
 
 def test_update_note_updates_fields(keep):
@@ -276,6 +287,10 @@ def test_delete_list_item_paths(keep):
 def test_list_item_requires_list_type(keep):
     with pytest.raises(ValueError, match="not a list"):
         cli.add_list_item("n1", "x")
+    with pytest.raises(ValueError, match="not a list"):
+        cli.update_list_item("n1", "i1", text="x")
+    with pytest.raises(ValueError, match="not a list"):
+        cli.delete_list_item("n1", "i1")
 
 
 def test_set_note_color_validates(keep, monkeypatch):
@@ -309,6 +324,8 @@ def test_label_crud_and_missing_label_errors(keep):
     message = json.loads(cli.delete_label(created["id"]))
     assert "marked for deletion" in message["message"]
 
+    with pytest.raises(ValueError, match="Label with ID bad not found"):
+        cli.delete_label("bad")
     with pytest.raises(ValueError, match="Label with ID bad not found"):
         cli.add_label_to_note("n1", "bad")
     with pytest.raises(ValueError, match="Label with ID bad not found"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -161,6 +161,9 @@ class DummyKeep:
     def getLabel(self, label_id):
         return self._labels.get(label_id)
 
+    def all(self):
+        return list(self.notes.values())
+
     def deleteLabel(self, label_id):
         self._labels.pop(label_id, None)
 
@@ -330,6 +333,26 @@ def test_label_crud_and_missing_label_errors(keep):
         cli.add_label_to_note("n1", "bad")
     with pytest.raises(ValueError, match="Label with ID bad not found"):
         cli.remove_label_from_note("n1", "bad")
+
+
+def test_delete_label_safe_mode_guards(keep, monkeypatch):
+    # Deleting the keep-mcp label is blocked in safe mode.
+    with pytest.raises(ValueError, match="keep-mcp"):
+        cli.delete_label("l1")
+
+    # Deleting a label that is on an unmanaged note is also blocked in safe mode.
+    unmanaged = DummyNote("unmanaged")  # no keep-mcp label
+    shared = DummyLabel("shared", "shared-tag")
+    keep._labels["shared"] = shared
+    unmanaged.labels.add(shared)
+    keep.notes["unmanaged"] = unmanaged
+    with pytest.raises(ValueError, match="unmanaged"):
+        cli.delete_label("shared")
+
+    # UNSAFE_MODE bypasses both guards.
+    monkeypatch.setenv("UNSAFE_MODE", "true")
+    msg = json.loads(cli.delete_label("shared"))
+    assert "marked for deletion" in msg["message"]
 
 
 def test_label_add_remove(keep):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,346 @@
+import json
+
+import pytest
+
+from server import cli
+
+
+class DummyLabel:
+    def __init__(self, label_id="l1", name="keep-mcp"):
+        self.id = label_id
+        self.name = name
+
+
+class DummyLabels:
+    def __init__(self):
+        self._labels = []
+
+    def add(self, label):
+        self._labels.append(label)
+
+    def remove(self, label):
+        self._labels = [existing for existing in self._labels if existing.id != label.id]
+
+    def all(self):
+        return self._labels
+
+
+class DummyCollaborators:
+    def __init__(self):
+        self._emails = []
+
+    def all(self):
+        return list(self._emails)
+
+    def add(self, email):
+        self._emails.append(email)
+
+    def remove(self, email):
+        self._emails = [value for value in self._emails if value != email]
+
+
+class DummyBlobType:
+    def __init__(self, value="IMAGE"):
+        self.value = value
+
+
+class DummyBlobInner:
+    def __init__(self):
+        self.type = DummyBlobType("IMAGE")
+
+
+class DummyBlob:
+    def __init__(self, blob_id="b1"):
+        self.id = blob_id
+        self.blob = DummyBlobInner()
+
+
+class DummyItem:
+    def __init__(self, item_id: str, text: str, checked: bool):
+        self.id = item_id
+        self.text = text
+        self.checked = checked
+        self.parent_item = None
+
+    def delete(self):
+        self.deleted = True
+
+
+class DummyNote:
+    def __init__(self, note_id="n1"):
+        self.id = note_id
+        self.title = "title"
+        self.text = "text"
+        self.pinned = False
+        self.archived = False
+        self.trashed = False
+        self.type = type("T", (), {"value": "NOTE"})()
+        self.color = type("C", (), {"value": "white"})()
+        self.labels = DummyLabels()
+        self.collaborators = DummyCollaborators()
+        self.blobs = [DummyBlob()]
+        self.deleted = False
+
+    def delete(self):
+        self.deleted = True
+
+    def trash(self):
+        self.trashed = True
+
+    def untrash(self):
+        self.trashed = False
+
+    def undelete(self):
+        self.deleted = False
+
+
+class DummyList(DummyNote):
+    def __init__(self, note_id="list1"):
+        super().__init__(note_id)
+        self.type = type("T", (), {"value": "LIST"})()
+        self.items = []
+
+    def add(self, text, checked=False):
+        item = DummyItem(f"i{len(self.items)+1}", text, checked)
+        self.items.append(item)
+        return item
+
+    def get(self, item_id):
+        for item in self.items:
+            if item.id == item_id:
+                return item
+        return None
+
+
+class DummyKeep:
+    def __init__(self):
+        self.notes = {}
+        self._labels = {"l1": DummyLabel("l1", "keep-mcp")}
+        self.sync_calls = 0
+
+    def sync(self):
+        self.sync_calls += 1
+
+    def find(self, **kwargs):
+        self.last_find_kwargs = kwargs
+        return list(self.notes.values())
+
+    def get(self, note_id):
+        return self.notes.get(note_id)
+
+    def createNote(self, title=None, text=None):
+        note = DummyNote("created")
+        note.title = title
+        note.text = text
+        self.notes[note.id] = note
+        return note
+
+    def createList(self, title=None, items=None):
+        note = DummyList("created_list")
+        note.title = title
+        if items:
+            for text, checked in items:
+                note.add(text, checked)
+        self.notes[note.id] = note
+        return note
+
+    def findLabel(self, name):
+        for label in self._labels.values():
+            if label.name == name:
+                return label
+        return None
+
+    def createLabel(self, name):
+        label = DummyLabel("new", name)
+        self._labels[label.id] = label
+        return label
+
+    def labels(self):
+        return list(self._labels.values())
+
+    def getLabel(self, label_id):
+        return self._labels.get(label_id)
+
+    def deleteLabel(self, label_id):
+        self._labels.pop(label_id, None)
+
+    def getMediaLink(self, blob):
+        return f"https://media/{blob.id}"
+
+
+@pytest.fixture()
+def keep(monkeypatch):
+    keep = DummyKeep()
+    keep.notes["n1"] = DummyNote("n1")
+    keep.notes["n1"].labels.add(DummyLabel("l1", "keep-mcp"))
+    keep.notes["list1"] = DummyList("list1")
+    keep.notes["list1"].labels.add(DummyLabel("l1", "keep-mcp"))
+    keep.notes["list1"].add("existing", checked=False)
+
+    monkeypatch.setattr(cli, "get_client", lambda: keep)
+    monkeypatch.setattr(cli.gkeepapi.node, "List", DummyList)
+    monkeypatch.setattr(
+        cli.gkeepapi.node,
+        "ColorValue",
+        lambda color: type("Color", (), {"value": color})(),
+    )
+    return keep
+
+
+def test_find_forwards_filters(keep):
+    result = json.loads(
+        cli.find(
+            query="q",
+            labels=["l1"],
+            colors=["red"],
+            pinned=True,
+            archived=False,
+            trashed=False,
+        )
+    )
+    assert keep.last_find_kwargs["query"] == "q"
+    assert keep.last_find_kwargs["labels"] == ["l1"]
+    assert isinstance(result, list)
+
+
+def test_get_note(keep):
+    data = json.loads(cli.get_note("n1"))
+    assert data["id"] == "n1"
+
+
+def test_create_note_labels_and_sync(keep):
+    data = json.loads(cli.create_note("t", "body"))
+    assert data["id"] == "created"
+    assert keep.sync_calls == 1
+
+
+def test_create_note_creates_label_when_missing(keep):
+    keep._labels = {}
+    data = json.loads(cli.create_note("t", "body"))
+    assert data["labels"][0]["name"] == "keep-mcp"
+
+
+def test_create_list_variants(keep):
+    data = json.loads(cli.create_list("list"))
+    assert data["id"] == "created_list"
+    data_with_items = json.loads(
+        cli.create_list("list", items=[{"text": "a", "checked": True}])
+    )
+    assert data_with_items["items"][0]["checked"] is True
+
+
+def test_update_note_updates_fields(keep):
+    data = json.loads(cli.update_note("n1", title="new", text="changed"))
+    assert data["title"] == "new"
+    assert data["text"] == "changed"
+
+
+def test_update_note_not_found_raises(keep):
+    with pytest.raises(ValueError, match="not found"):
+        cli.update_note("missing", title="x")
+
+
+def test_list_item_roundtrip(keep):
+    add = json.loads(cli.add_list_item("list1", "task", checked=True))
+    item_id = add["item_id"]
+    updated = json.loads(
+        cli.update_list_item("list1", item_id, text="task2", checked=False)
+    )
+    assert any(item["id"] == item_id for item in updated["items"])
+
+
+def test_update_list_item_missing_item_raises(keep):
+    with pytest.raises(ValueError, match="not found"):
+        cli.update_list_item("list1", "missing", text="x")
+
+
+def test_delete_list_item_paths(keep):
+    with pytest.raises(ValueError, match="not found"):
+        cli.delete_list_item("list1", "missing")
+
+    new_item_id = json.loads(cli.add_list_item("list1", "task"))["item_id"]
+    data = json.loads(cli.delete_list_item("list1", new_item_id))
+    assert "marked for deletion" in data["message"]
+
+
+def test_list_item_requires_list_type(keep):
+    with pytest.raises(ValueError, match="not a list"):
+        cli.add_list_item("n1", "x")
+
+
+def test_set_note_color_validates(keep, monkeypatch):
+    def bad_color(_):
+        raise ValueError("bad")
+
+    monkeypatch.setattr(cli.gkeepapi.node, "ColorValue", bad_color)
+    with pytest.raises(ValueError, match="Invalid color"):
+        cli.set_note_color("n1", "invalid")
+
+
+def test_note_state_transitions(keep):
+    assert json.loads(cli.set_note_color("n1", "red"))["color"] == "red"
+    assert json.loads(cli.pin_note("n1", True))["pinned"] is True
+    assert json.loads(cli.archive_note("n1", True))["archived"] is True
+    assert json.loads(cli.trash_note("n1"))["trashed"] is True
+    assert json.loads(cli.restore_note("n1"))["trashed"] is False
+
+
+def test_delete_note_marks_deleted(keep):
+    msg = json.loads(cli.delete_note("n1"))
+    assert "marked for deletion" in msg["message"]
+
+
+def test_label_crud_and_missing_label_errors(keep):
+    labels = json.loads(cli.list_labels())
+    assert labels
+
+    created = json.loads(cli.create_label("other"))
+    assert created["name"] == "other"
+    message = json.loads(cli.delete_label(created["id"]))
+    assert "marked for deletion" in message["message"]
+
+    with pytest.raises(ValueError, match="Label with ID bad not found"):
+        cli.add_label_to_note("n1", "bad")
+    with pytest.raises(ValueError, match="Label with ID bad not found"):
+        cli.remove_label_from_note("n1", "bad")
+
+
+def test_label_add_remove(keep):
+    keep._labels["l2"] = DummyLabel("l2", "other")
+    add = json.loads(cli.add_label_to_note("n1", "l2"))
+    assert any(label["id"] == "l2" for label in add["labels"])
+    remove = json.loads(cli.remove_label_from_note("n1", "l2"))
+    assert all(label["id"] != "l2" for label in remove["labels"])
+
+
+def test_collaborator_list_add_remove(keep):
+    before = json.loads(cli.list_note_collaborators("n1"))
+    assert before == []
+
+    data = json.loads(cli.add_note_collaborator("n1", "user@example.com"))
+    assert "user@example.com" in data["collaborators"]
+    after = json.loads(cli.remove_note_collaborator("n1", "user@example.com"))
+    assert "user@example.com" not in after["collaborators"]
+
+
+def test_list_note_media(keep):
+    media = json.loads(cli.list_note_media("n1"))
+    assert media[0]["media_link"].startswith("https://media/")
+
+
+def test_modification_guard_blocks_when_unlabeled(keep, monkeypatch):
+    keep.notes["n1"].labels = DummyLabels()
+    monkeypatch.setattr(cli, "can_modify_note", lambda _: False)
+    with pytest.raises(ValueError, match="cannot be modified"):
+        cli.update_note("n1", title="x")
+
+
+def test_main_runs_stdio_transport(monkeypatch):
+    captured = {}
+
+    def fake_run(*, transport):
+        captured["transport"] = transport
+
+    monkeypatch.setattr(cli.mcp, "run", fake_run)
+    cli.main()
+    assert captured["transport"] == "stdio"

--- a/tests/test_keep_api.py
+++ b/tests/test_keep_api.py
@@ -1,0 +1,91 @@
+from types import SimpleNamespace
+
+from server.keep_api import can_modify_note, serialize_note
+
+
+class DummyLabels:
+    def __init__(self, labels):
+        self._labels = labels
+
+    def all(self):
+        return self._labels
+
+
+class DummyCollaborators:
+    def __init__(self, emails):
+        self._emails = emails
+
+    def all(self):
+        return self._emails
+
+
+class DummyBlobType:
+    def __init__(self, value):
+        self.value = value
+
+
+class DummyBlobNode:
+    def __init__(self, blob_id, blob_type):
+        self.id = blob_id
+        self.blob = SimpleNamespace(type=DummyBlobType(blob_type))
+
+
+class DummyNote:
+    def __init__(self):
+        self.id = "n1"
+        self.title = "title"
+        self.text = "text"
+        self.type = SimpleNamespace(value="NOTE")
+        self.pinned = False
+        self.archived = False
+        self.trashed = False
+        self.color = SimpleNamespace(value="white")
+        self.labels = DummyLabels([SimpleNamespace(id="l1", name="keep-mcp")])
+        self.collaborators = DummyCollaborators(["alice@example.com"])
+        self.blobs = [DummyBlobNode("b1", "IMAGE")]
+
+
+class DummyListNote(DummyNote):
+    def __init__(self):
+        super().__init__()
+        self.items = [
+            SimpleNamespace(
+                id="i1",
+                text="item",
+                checked=False,
+                parent_item=None,
+            )
+        ]
+
+
+def test_serialize_note_for_note_type():
+    data = serialize_note(DummyNote())
+    assert data["id"] == "n1"
+    assert data["labels"][0]["name"] == "keep-mcp"
+    assert data["collaborators"] == ["alice@example.com"]
+    assert data["media"][0]["type"] == "IMAGE"
+    assert "items" not in data
+
+
+def test_serialize_note_for_list_type():
+    data = serialize_note(DummyListNote())
+    assert data["items"][0]["id"] == "i1"
+
+
+def test_can_modify_note_respects_label(monkeypatch):
+    monkeypatch.delenv("UNSAFE_MODE", raising=False)
+    assert can_modify_note(DummyNote()) is True
+
+
+def test_can_modify_note_respects_unsafe_mode(monkeypatch):
+    monkeypatch.setenv("UNSAFE_MODE", "true")
+    note = DummyNote()
+    note.labels = DummyLabels([])
+    assert can_modify_note(note) is True
+
+
+def test_can_modify_note_false_without_label_or_unsafe(monkeypatch):
+    monkeypatch.delenv("UNSAFE_MODE", raising=False)
+    note = DummyNote()
+    note.labels = DummyLabels([])
+    assert can_modify_note(note) is False

--- a/tests/test_keep_client.py
+++ b/tests/test_keep_client.py
@@ -1,0 +1,41 @@
+from server import keep_api
+
+
+class DummyKeep:
+    def __init__(self):
+        self.auth_calls = []
+
+    def authenticate(self, email, token):
+        self.auth_calls.append((email, token))
+
+
+def test_get_client_authenticates_and_caches(monkeypatch):
+    keep_api._keep_client = None
+    created = DummyKeep()
+
+    monkeypatch.setattr(keep_api, "load_dotenv", lambda: None)
+    monkeypatch.setattr(keep_api.os, "getenv", lambda key: {
+        "GOOGLE_EMAIL": "user@example.com",
+        "GOOGLE_MASTER_TOKEN": "token",
+    }.get(key))
+    monkeypatch.setattr(keep_api.gkeepapi, "Keep", lambda: created)
+
+    first = keep_api.get_client()
+    second = keep_api.get_client()
+
+    assert first is created
+    assert second is created
+    assert created.auth_calls == [("user@example.com", "token")]
+
+
+def test_get_client_raises_when_missing_credentials(monkeypatch):
+    keep_api._keep_client = None
+    monkeypatch.setattr(keep_api, "load_dotenv", lambda: None)
+    monkeypatch.setattr(keep_api.os, "getenv", lambda _key: None)
+
+    try:
+        keep_api.get_client()
+    except ValueError as exc:
+        assert "Missing Google Keep credentials" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for missing credentials")

--- a/tests/test_main_module.py
+++ b/tests/test_main_module.py
@@ -1,0 +1,14 @@
+import runpy
+
+
+def test_main_module_calls_cli_main(monkeypatch):
+    called = {"value": False}
+
+    def fake_main():
+        called["value"] = True
+
+    import server.cli
+
+    monkeypatch.setattr(server.cli, "main", fake_main)
+    runpy.run_module("server.__main__", run_name="__main__")
+    assert called["value"] is True


### PR DESCRIPTION
## Summary

This PR expands `keep-mcp` from a basic note CRUD server into a fuller Google Keep MCP surface, while tightening safety guarantees around destructive operations and improving developer workflow, test coverage, and documentation.

Compared to `main`, this branch changes 12 files (`+1319 / -90`) and adds CI, Make targets, a smoke test, and a broad unit test suite.

## Why

- Improve reliability when Keep authentication fails in non-obvious ways.
- Expose more of Google Keep’s capabilities through MCP tools.
- Prevent “safe mode” workflows from accidentally making notes permanently unmodifiable.
- Make local setup/testing and client integration easier and better documented.

## What Changed

### 1) Keep API reliability and serialization (`src/server/keep_api.py`)

- Added `KEEP_MCP_LABEL` constant.
- Added explicit auth error handling for:
- `requests.exceptions.JSONDecodeError` with a clear “Keep API unreachable/non-JSON response” runtime message.
- `gkeepapi.exception.LoginException` with credential-focused guidance.
- Expanded note serialization:
- New fields: `type`, `archived`, `trashed`, `collaborators`, `media`.
- List notes now include serialized `items`.
- Added helper serializers for labels and list items.
- Added `is_unsafe_mode()` helper and reused it in modification checks.

### 2) MCP CLI tool surface and safety guards (`src/server/cli.py`)

- Added shared helpers:
- `_get_note_or_raise(note_id)`
- `_ensure_modifiable(note)`
- `_normalize_colors(colors)`
- Expanded `find` to support filters: `labels`, `colors`, `pinned`, `archived`, `trashed`, including color normalization/validation.
- Added `get_note`.
- Added checklist support:
- `create_list`
- `add_list_item`
- `update_list_item`
- `delete_list_item`
- Added note state tools:
- `set_note_color`
- `pin_note`
- `archive_note`
- `trash_note`
- `restore_note`
- Added label tools:
- `list_labels`
- `create_label`
- `delete_label`
- `add_label_to_note`
- `remove_label_from_note`
- Added collaborator/media tools:
- `list_note_collaborators`
- `add_note_collaborator`
- `remove_note_collaborator`
- `list_note_media`
- Preserved safe-mode behavior for note mutation and tightened guardrails:
- `remove_label_from_note` now blocks removing `keep-mcp` label in safe mode.
- `delete_label` now blocks deleting:
- the `keep-mcp` label in safe mode.
- any label attached to unmanaged notes in safe mode.
- `UNSAFE_MODE=true` explicitly bypasses these guards.

### 3) Dev workflow and CI

- Added `Makefile` with:
- `install`, `start`, `test`, `smoke`, `lint`
- uv-based virtualenv and command wrappers.
- Added CI workflow (`.github/workflows/ci.yml`):
- Python 3.10/3.11/3.12 matrix
- `ruff check .`
- `pytest` with coverage gate (`--cov-fail-under=70`)
- `python -m compileall src`
- Updated `.gitignore` for test artifacts (`.coverage`, `htmlcov/`, `.pytest_cache/`).

### 4) Tests and smoke coverage

- Added/expanded tests:
- `tests/test_cli.py` (tool behavior, validation, safe-mode guards, media/collaborators, stdio entrypoint)
- `tests/test_keep_api.py` (serialization + modification guard logic)
- `tests/test_keep_client.py` (client auth/caching and missing-credential handling)
- `tests/test_main_module.py` (`python -m server` wiring)
- `tests/conftest.py` (test import path bootstrap)
- Added real-account smoke script (`scripts/smoke_test.py`) covering note/list/label lifecycle flows.

### 5) Documentation (`README.md`)

- Reorganized and expanded feature list by capability area.
- Added local dev workflow using `make` + `uv`.
- Documented unit tests, smoke tests, and CI checks.
- Added instructions for running from local checkout in MCP clients (`config.toml` and JSON `mcpServers` examples).

## Behavioral Impact

- Safer defaults in non-unsafe mode around label operations.
- Richer serialized note payloads (additional fields now included).
- More complete MCP API coverage for lists, labels, collaborators, and media.
- More actionable auth failures when Keep API access is blocked or credentials are invalid.

## Validation

- `make test` → `32 passed in 0.30s`
- Coverage CLI command requires `pytest-cov` locally; coverage gate is enforced in CI workflow.