### PR TITLE
feat: Add Docker support with secret-file token injection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY pyproject.toml .
+COPY LICENSE .
+COPY README.md .
+COPY src/ src/
+
+RUN pip install --no-cache-dir .
+
+ENV GOOGLE_EMAIL=""
+ENV UNSAFE_MODE="false"
+
+CMD ["python", "-m", "server"]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ MCP server for Google Keep
 
 ## How to use
 
+### Python
+
 1. Add the MCP server to your MCP servers:
 
 ```json
@@ -29,6 +31,62 @@ MCP server for Google Keep
 * `GOOGLE_MASTER_TOKEN`: Your Google account master token
 
 Check https://gkeepapi.readthedocs.io/en/latest/#obtaining-a-master-token and https://github.com/simon-weber/gpsoauth?tab=readme-ov-file#alternative-flow for more information.
+
+### Docker
+
+Build the image from source:
+
+```bash
+docker build -t keep-mcp .
+```
+
+Then add it to your MCP client config using `docker run`:
+
+```json
+"mcpServers": {
+  "keep-mcp-docker": {
+    "command": "docker",
+    "args": [
+      "run", "--rm", "-i",
+      "-e", "GOOGLE_EMAIL",
+      "-e", "GOOGLE_MASTER_TOKEN"
+    ],
+    "env": {
+      "GOOGLE_EMAIL": "you@example.com",
+      "GOOGLE_MASTER_TOKEN": "your-master-token"
+    }
+  }
+}
+```
+
+> **Note:** The `-i` flag is required for stdio-based MCP communication. `UNSAFE_MODE=true` can be added as an extra `-e UNSAFE_MODE` argument if needed.
+
+#### Passing the token as a Docker secret (recommended)
+
+Instead of passing `GOOGLE_MASTER_TOKEN` as an environment variable, you can mount it as a file:
+
+```bash
+# Write your token to a file (chmod 600 recommended)
+echo -n "your-master-token" > /run/secrets/google_master_token
+chmod 600 /run/secrets/google_master_token
+```
+
+# Then use
+```
+"mcpServers": {
+  "keep-mcp-docker": {
+    "command": "docker",
+    "args": [
+      "run", "--rm", "-i",
+      "-e", "GOOGLE_EMAIL=you@example.com",
+      "-v", "/run/secrets/google_master_token:/run/secrets/google_master_token:ro",
+      "keep-mcp"
+    ]
+  }
+}
+```
+
+The server reads `/run/secrets/google_master_token` first; if absent it falls back to the `GOOGLE_MASTER_TOKEN` environment variable.
 
 ## Features
 

--- a/src/server/keep_api.py
+++ b/src/server/keep_api.py
@@ -7,6 +7,14 @@ KEEP_MCP_LABEL = "keep-mcp"
 
 _keep_client = None
 
+
+def _read_secret(env_var: str, secret_name: str) -> str | None:
+    secret_path = f"/run/secrets/{secret_name}"
+    if os.path.exists(secret_path):
+        with open(secret_path) as f:
+            return f.read().strip()
+    return os.getenv(env_var)
+
 def get_client():
     """
     Get or initialize the Google Keep client.
@@ -23,9 +31,9 @@ def get_client():
     # Load environment variables
     load_dotenv()
     
-    # Get credentials from environment variables
+    # Get credentials from environment variables or secret files
     email = os.getenv('GOOGLE_EMAIL')
-    master_token = os.getenv('GOOGLE_MASTER_TOKEN')
+    master_token = _read_secret('GOOGLE_MASTER_TOKEN', 'google_master_token')
     
     if not email or not master_token:
         raise ValueError("Missing Google Keep credentials. Please set GOOGLE_EMAIL and GOOGLE_MASTER_TOKEN environment variables.")

--- a/tests/test_keep_client.py
+++ b/tests/test_keep_client.py
@@ -1,3 +1,4 @@
+import io
 from server import keep_api
 
 
@@ -26,6 +27,23 @@ def test_get_client_authenticates_and_caches(monkeypatch):
     assert first is created
     assert second is created
     assert created.auth_calls == [("user@example.com", "token")]
+
+
+def test_get_client_reads_token_from_secret_file(monkeypatch):
+    keep_api._keep_client = None
+    created = DummyKeep()
+
+    monkeypatch.setattr(keep_api, "load_dotenv", lambda: None)
+    monkeypatch.setattr(keep_api.os, "getenv", lambda key: {
+        "GOOGLE_EMAIL": "user@example.com",
+    }.get(key))
+    monkeypatch.setattr(keep_api.os.path, "exists", lambda p: p == "/run/secrets/google_master_token")
+    monkeypatch.setattr("builtins.open", lambda p, *a, **kw: io.StringIO("token-from-file\n"))
+    monkeypatch.setattr(keep_api.gkeepapi, "Keep", lambda: created)
+
+    keep_api.get_client()
+
+    assert created.auth_calls == [("user@example.com", "token-from-file")]
 
 
 def test_get_client_raises_when_missing_credentials(monkeypatch):


### PR DESCRIPTION
### Summary

- Add a Dockerfile to run keep-mcp as a containerized MCP server
- Support reading GOOGLE_MASTER_TOKEN from /run/secrets/google_master_token as a more secure alternative to passing the token as an environment variable (falls back to the env var if the file is absent)
- Update README with Docker usage instructions, including both env-var and secret-file approaches
- Add a test covering the secret-file token resolution path

### How to test

- Build the image: docker build -t keep-mcp .
- Run pytest tests/test_keep_client.py to validate the new secret-file test passes
- Run with env var or mount a token file at /run/secrets/google_master_token and verify the server authenticates correctly