### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ By default, all destructive and modification operations are restricted to notes 
 }
 ```
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/feuerdev-keep-mcp).
+
 ## Local development (uv + make)
 
 If you prefer a JS-style workflow (`npm i`, `npm start`), use the included `Makefile`:


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/feuerdev-keep-mcp).