### PR TITLE
fix: MCP SDK 2.0 support, dependency bounds, and console-script rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,23 @@ MCP server for Google Keep
   }
 ```
 
+Or with `uvx`:
+
+```json
+  "mcpServers": {
+    "keep-mcp": {
+      "command": "uvx",
+      "args": [
+        "keep-mcp"
+      ],
+      "env": {
+        "GOOGLE_EMAIL": "Your Google Email",
+        "GOOGLE_MASTER_TOKEN": "Your Google Master Token - see README.md"
+      }
+    }
+  }
+```
+
 2. Add your credentials:
 * `GOOGLE_EMAIL`: Your Google account email address
 * `GOOGLE_MASTER_TOKEN`: Your Google account master token

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,9 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "gkeepapi>=0.16.0",
-    "mcp[cli]",
+    "mcp[cli]>=1.2,<3",
+    "python-dotenv>=1.0",
+    "requests>=2.28",
 ]
 authors = [
     { name = "Jannik Feuerhahn", email = "jannik@feuer.dev" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ Homepage = "https://github.com/feuerdev/keep-mcp"
 Repository = "https://github.com/feuerdev/keep-mcp"
 
 [project.scripts]
-mcp = "server.cli:main"
+keep-mcp = "server.cli:main"
 
 [build-system]
 requires = ["hatchling >= 1.26"]

--- a/src/server/cli.py
+++ b/src/server/cli.py
@@ -7,11 +7,23 @@ import json
 from typing import Any
 
 import gkeepapi
-from mcp.server.fastmcp import FastMCP
 
-from .keep_api import KEEP_MCP_LABEL, can_modify_note, get_client, has_keep_mcp_label, is_unsafe_mode, serialize_label, serialize_note
+try:
+    from mcp.server import MCPServer
+except ImportError:  # MCP SDK 1.x: FastMCP became MCPServer in 2.0
+    from mcp.server.fastmcp import FastMCP as MCPServer
 
-mcp = FastMCP("keep")
+from .keep_api import (
+    KEEP_MCP_LABEL,
+    can_modify_note,
+    get_client,
+    has_keep_mcp_label,
+    is_unsafe_mode,
+    serialize_label,
+    serialize_note,
+)
+
+mcp = MCPServer("keep")
 
 
 def _get_note_or_raise(note_id: str):
@@ -124,7 +136,7 @@ def add_list_item(note_id: str, text: str, checked: bool = False) -> str:
     _ensure_modifiable(note)
 
     if not isinstance(note, gkeepapi.node.List):
-        raise ValueError(f"Note with ID {note_id} is not a list")
+        raise TypeError(f"Note with ID {note_id} is not a list")
 
     item = note.add(text=text, checked=checked)
     keep.sync()
@@ -138,7 +150,7 @@ def update_list_item(note_id: str, item_id: str, text: str | None = None, checke
     _ensure_modifiable(note)
 
     if not isinstance(note, gkeepapi.node.List):
-        raise ValueError(f"Note with ID {note_id} is not a list")
+        raise TypeError(f"Note with ID {note_id} is not a list")
 
     item = note.get(item_id)
     if not item:
@@ -160,7 +172,7 @@ def delete_list_item(note_id: str, item_id: str) -> str:
     _ensure_modifiable(note)
 
     if not isinstance(note, gkeepapi.node.List):
-        raise ValueError(f"Note with ID {note_id} is not a list")
+        raise TypeError(f"Note with ID {note_id} is not a list")
 
     item = note.get(item_id)
     if not item:

--- a/src/server/keep_api.py
+++ b/src/server/keep_api.py
@@ -1,5 +1,6 @@
-import gkeepapi
 import os
+
+import gkeepapi
 import requests
 from dotenv import load_dotenv
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -288,11 +288,11 @@ def test_delete_list_item_paths(keep):
 
 
 def test_list_item_requires_list_type(keep):
-    with pytest.raises(ValueError, match="not a list"):
+    with pytest.raises(TypeError, match="not a list"):
         cli.add_list_item("n1", "x")
-    with pytest.raises(ValueError, match="not a list"):
+    with pytest.raises(TypeError, match="not a list"):
         cli.update_list_item("n1", "i1", text="x")
-    with pytest.raises(ValueError, match="not a list"):
+    with pytest.raises(TypeError, match="not a list"):
         cli.delete_list_item("n1", "i1")
 
 


### PR DESCRIPTION
Hi! Thanks for keep-mcp — it has been part of my daily setup for a while now.

MCP SDK 2.0.0 removed `mcp.server.fastmcp` (FastMCP is now `mcp.server.MCPServer`), so every fresh install currently fails at import with "Connection closed" at the client end, and the lint job fails on current ruff defaults. This PR:

- imports `MCPServer` with a FastMCP fallback, so both SDK 1.x and 2.x work
- bounds `mcp[cli]>=1.2,<3` and declares `python-dotenv` + `requests` as direct dependencies (both are imported directly by `keep_api.py` but previously arrived only transitively)
- fixes what current ruff flags: import ordering and TRY004 (TypeError for the is-it-a-list checks)
- renames the console script `mcp` → `keep-mcp`: the old name collides with the MCP SDK's own `mcp` CLI from the `mcp[cli]` extra, so which binary wins depends on resolution order; the rename also makes `pipx run keep-mcp` / `uvx keep-mcp` resolve by name. Marked BREAKING in the commit for your release automation.

`pytest` (32 passed) and `ruff check` are green under SDK 2.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)