### PR TITLE
feat: date filters, result limit, and case-insensitive search for find

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,23 @@ MCP server for Google Keep
   }
 ```
 
+Or with `uvx`:
+
+```json
+  "mcpServers": {
+    "keep-mcp": {
+      "command": "uvx",
+      "args": [
+        "keep-mcp"
+      ],
+      "env": {
+        "GOOGLE_EMAIL": "Your Google Email",
+        "GOOGLE_MASTER_TOKEN": "Your Google Master Token - see README.md"
+      }
+    }
+  }
+```
+
 2. Add your credentials:
 * `GOOGLE_EMAIL`: Your Google account email address
 * `GOOGLE_MASTER_TOKEN`: Your Google account master token

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Check https://gkeepapi.readthedocs.io/en/latest/#obtaining-a-master-token and ht
 ## Features
 
 ### Query and read tools
-* `find`: Search notes with optional filters for labels, colors, pinned, archived, and trashed
+* `find`: Search notes (case-insensitive by default) with optional filters for labels, colors, pinned, archived, trashed, creation/update date ranges (ISO 8601, UTC), and a result limit
 * `get_note`: Get a single note by ID
 
 ### Creation and update tools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,9 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "gkeepapi>=0.16.0",
-    "mcp[cli]",
+    "mcp[cli]>=1.2,<3",
+    "python-dotenv>=1.0",
+    "requests>=2.28",
 ]
 authors = [
     { name = "Jannik Feuerhahn", email = "jannik@feuer.dev" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ Homepage = "https://github.com/feuerdev/keep-mcp"
 Repository = "https://github.com/feuerdev/keep-mcp"
 
 [project.scripts]
-mcp = "server.cli:main"
+keep-mcp = "server.cli:main"
 
 [build-system]
 requires = ["hatchling >= 1.26"]

--- a/src/server/cli.py
+++ b/src/server/cli.py
@@ -7,11 +7,23 @@ import json
 from typing import Any
 
 import gkeepapi
-from mcp.server.fastmcp import FastMCP
 
-from .keep_api import KEEP_MCP_LABEL, can_modify_note, get_client, has_keep_mcp_label, is_unsafe_mode, serialize_label, serialize_note
+try:
+    from mcp.server import MCPServer
+except ImportError:  # MCP SDK 1.x: FastMCP became MCPServer in 2.0
+    from mcp.server.fastmcp import FastMCP as MCPServer
 
-mcp = FastMCP("keep")
+from .keep_api import (
+    KEEP_MCP_LABEL,
+    can_modify_note,
+    get_client,
+    has_keep_mcp_label,
+    is_unsafe_mode,
+    serialize_label,
+    serialize_note,
+)
+
+mcp = MCPServer("keep")
 
 
 def _get_note_or_raise(note_id: str):
@@ -124,7 +136,7 @@ def add_list_item(note_id: str, text: str, checked: bool = False) -> str:
     _ensure_modifiable(note)
 
     if not isinstance(note, gkeepapi.node.List):
-        raise ValueError(f"Note with ID {note_id} is not a list")
+        raise TypeError(f"Note with ID {note_id} is not a list")
 
     item = note.add(text=text, checked=checked)
     keep.sync()
@@ -138,7 +150,7 @@ def update_list_item(note_id: str, item_id: str, text: str | None = None, checke
     _ensure_modifiable(note)
 
     if not isinstance(note, gkeepapi.node.List):
-        raise ValueError(f"Note with ID {note_id} is not a list")
+        raise TypeError(f"Note with ID {note_id} is not a list")
 
     item = note.get(item_id)
     if not item:
@@ -160,7 +172,7 @@ def delete_list_item(note_id: str, item_id: str) -> str:
     _ensure_modifiable(note)
 
     if not isinstance(note, gkeepapi.node.List):
-        raise ValueError(f"Note with ID {note_id} is not a list")
+        raise TypeError(f"Note with ID {note_id} is not a list")
 
     item = note.get(item_id)
     if not item:

--- a/src/server/cli.py
+++ b/src/server/cli.py
@@ -4,6 +4,9 @@ Provides tools for interacting with Google Keep notes through MCP.
 """
 
 import json
+import re
+from datetime import datetime, timezone
+from itertools import islice
 from typing import Any
 
 import gkeepapi
@@ -56,6 +59,51 @@ def _normalize_colors(colors: list[str] | None):
     return normalized_colors
 
 
+def _parse_utc(value: str | None, param: str) -> datetime | None:
+    if value is None:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(
+            f"Invalid {param} '{value}': expected ISO 8601, "
+            "e.g. 2026-07-29 or 2026-07-29T12:00:00Z"
+        ) from exc
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _as_utc(value: datetime | None) -> datetime | None:
+    if value is None or value.tzinfo is not None:
+        return value
+    return value.replace(tzinfo=timezone.utc)
+
+
+def _build_time_filter(
+    created_after: datetime | None,
+    created_before: datetime | None,
+    updated_after: datetime | None,
+    updated_before: datetime | None,
+):
+    if not any((created_after, created_before, updated_after, updated_before)):
+        return None
+
+    def within(note) -> bool:
+        timestamps = getattr(note, "timestamps", None)
+        created = _as_utc(getattr(timestamps, "created", None))
+        updated = _as_utc(getattr(timestamps, "updated", None))
+        if created_after and (created is None or created < created_after):
+            return False
+        if created_before and (created is None or created >= created_before):
+            return False
+        if updated_after and (updated is None or updated < updated_after):
+            return False
+        return not (updated_before and (updated is None or updated >= updated_before))
+
+    return within
+
+
 @mcp.tool()
 def find(
     query: str = "",
@@ -64,18 +112,47 @@ def find(
     pinned: bool | None = None,
     archived: bool | None = False,
     trashed: bool = False,
+    case_sensitive: bool = False,
+    created_after: str | None = None,
+    created_before: str | None = None,
+    updated_after: str | None = None,
+    updated_before: str | None = None,
+    limit: int | None = None,
 ) -> str:
-    """Find notes using text and optional filters. labels should be label IDs. colors should be ColorValue strings (e.g. DEFAULT, RED, CERULEAN)."""
+    """Find notes using text and optional filters.
+
+    query matches title and text, case-insensitively unless case_sensitive
+    is true. labels should be label IDs. colors should be ColorValue strings
+    (e.g. DEFAULT, RED, CERULEAN). The date bounds accept ISO 8601 dates or
+    datetimes, interpreted as UTC when no timezone is given (e.g. 2026-07-29
+    or 2026-07-29T12:00:00Z); after-bounds are inclusive, before-bounds
+    exclusive. limit caps the number of returned notes.
+    """
     keep = get_client()
     normalized_colors = _normalize_colors(colors)
+
+    search_query: str | re.Pattern = query
+    if query and not case_sensitive:
+        search_query = re.compile(re.escape(query), re.IGNORECASE)
+
+    time_filter = _build_time_filter(
+        _parse_utc(created_after, "created_after"),
+        _parse_utc(created_before, "created_before"),
+        _parse_utc(updated_after, "updated_after"),
+        _parse_utc(updated_before, "updated_before"),
+    )
+
     notes = keep.find(
-        query=query,
+        query=search_query,
+        func=time_filter,
         labels=labels,
         colors=normalized_colors,
         pinned=pinned,
         archived=archived,
         trashed=trashed,
     )
+    if limit is not None:
+        notes = islice(notes, max(limit, 0))
 
     notes_data = [serialize_note(note) for note in notes]
     return json.dumps(notes_data)

--- a/src/server/keep_api.py
+++ b/src/server/keep_api.py
@@ -79,6 +79,10 @@ def serialize_note(note):
     Returns:
         dict: A dictionary containing the note's id, title, text, pinned status, color and labels
     """
+    timestamps = getattr(note, 'timestamps', None)
+    created = getattr(timestamps, 'created', None)
+    updated = getattr(timestamps, 'updated', None)
+
     payload = {
         'id': note.id,
         'title': note.title,
@@ -88,6 +92,8 @@ def serialize_note(note):
         'archived': note.archived,
         'trashed': note.trashed,
         'color': note.color.value if note.color else None,
+        'created': created.isoformat() if created else None,
+        'updated': updated.isoformat() if updated else None,
         'labels': [serialize_label(label) for label in note.labels.all()],
         'collaborators': list(note.collaborators.all()),
     }

--- a/src/server/keep_api.py
+++ b/src/server/keep_api.py
@@ -1,5 +1,6 @@
-import gkeepapi
 import os
+
+import gkeepapi
 import requests
 from dotenv import load_dotenv
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -288,11 +288,11 @@ def test_delete_list_item_paths(keep):
 
 
 def test_list_item_requires_list_type(keep):
-    with pytest.raises(ValueError, match="not a list"):
+    with pytest.raises(TypeError, match="not a list"):
         cli.add_list_item("n1", "x")
-    with pytest.raises(ValueError, match="not a list"):
+    with pytest.raises(TypeError, match="not a list"):
         cli.update_list_item("n1", "i1", text="x")
-    with pytest.raises(ValueError, match="not a list"):
+    with pytest.raises(TypeError, match="not a list"):
         cli.delete_list_item("n1", "i1")
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,7 @@
 import json
+import re
+from datetime import datetime, timezone
+from types import SimpleNamespace
 
 import pytest
 
@@ -201,7 +204,7 @@ def test_find_forwards_filters(keep):
             trashed=False,
         )
     )
-    assert keep.last_find_kwargs["query"] == "q"
+    assert keep.last_find_kwargs["query"].pattern == "q"
     assert keep.last_find_kwargs["labels"] == ["l1"]
     assert [color.value for color in keep.last_find_kwargs["colors"]] == ["red"]
     assert isinstance(result, list)
@@ -210,6 +213,54 @@ def test_find_forwards_filters(keep):
 def test_find_without_colors_passes_none(keep):
     cli.find(query="q")
     assert keep.last_find_kwargs["colors"] is None
+
+
+def test_find_query_case_insensitive_by_default(keep):
+    cli.find(query="Hello")
+    pattern = keep.last_find_kwargs["query"]
+    assert isinstance(pattern, re.Pattern)
+    assert pattern.search("say HELLO there")
+    assert pattern.search("no match here") is None
+
+
+def test_find_query_case_sensitive_opt_in(keep):
+    cli.find(query="Hello", case_sensitive=True)
+    assert keep.last_find_kwargs["query"] == "Hello"
+
+
+def test_find_empty_query_and_no_dates_pass_through(keep):
+    cli.find()
+    assert keep.last_find_kwargs["query"] == ""
+    assert keep.last_find_kwargs["func"] is None
+
+
+def test_find_date_filter_func(keep):
+    cli.find(created_after="2026-07-01", updated_before="2026-08-01T00:00:00Z")
+    within = keep.last_find_kwargs["func"]
+
+    def note_with(created, updated):
+        return SimpleNamespace(
+            timestamps=SimpleNamespace(created=created, updated=updated)
+        )
+
+    utc = timezone.utc
+    assert within(note_with(datetime(2026, 7, 15, tzinfo=utc), datetime(2026, 7, 20, tzinfo=utc))) is True
+    assert within(note_with(datetime(2026, 6, 15, tzinfo=utc), datetime(2026, 7, 20, tzinfo=utc))) is False
+    assert within(note_with(datetime(2026, 7, 15, tzinfo=utc), datetime(2026, 8, 2, tzinfo=utc))) is False
+    # Naive timestamps (older gkeepapi) are treated as UTC, not an error.
+    assert within(note_with(datetime(2026, 7, 15), datetime(2026, 7, 20))) is True  # noqa: DTZ001
+    assert within(SimpleNamespace(timestamps=None)) is False
+
+
+def test_find_invalid_date_raises(keep):
+    with pytest.raises(ValueError, match="created_after"):
+        cli.find(created_after="not-a-date")
+
+
+def test_find_limit_caps_results(keep):
+    assert len(json.loads(cli.find())) == 2
+    assert len(json.loads(cli.find(limit=1))) == 1
+    assert json.loads(cli.find(limit=0)) == []
 
 
 def test_find_invalid_color_raises(keep, monkeypatch):

--- a/tests/test_keep_api.py
+++ b/tests/test_keep_api.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from types import SimpleNamespace
 
 from server.keep_api import can_modify_note, serialize_note
@@ -70,6 +71,23 @@ def test_serialize_note_for_note_type():
 def test_serialize_note_for_list_type():
     data = serialize_note(DummyListNote())
     assert data["items"][0]["id"] == "i1"
+
+
+def test_serialize_note_includes_timestamps():
+    note = DummyNote()
+    note.timestamps = SimpleNamespace(
+        created=datetime(2026, 7, 1, 12, 0, 0, tzinfo=timezone.utc),
+        updated=datetime(2026, 7, 2, 8, 30, 0, tzinfo=timezone.utc),
+    )
+    data = serialize_note(note)
+    assert data["created"] == "2026-07-01T12:00:00+00:00"
+    assert data["updated"] == "2026-07-02T08:30:00+00:00"
+
+
+def test_serialize_note_without_timestamps_yields_none():
+    data = serialize_note(DummyNote())
+    assert data["created"] is None
+    assert data["updated"] is None
 
 
 def test_can_modify_note_respects_label(monkeypatch):


### PR DESCRIPTION
Builds on #15 — its commits appear in this diff until that one merges, so best reviewed/merged after it.

- `find` gains `created_after` / `created_before` / `updated_after` / `updated_before` (ISO 8601 dates or datetimes, treated as UTC when no timezone is given), filtered server-side via gkeepapi's `func` hook. Motivation: my account returns ~200 notes (~70KB) on every unfiltered call; a "notes from yesterday onward" query is now ~1KB.
- `limit` caps the number of returned notes.
- `query` now matches case-insensitively by default; `case_sensitive=true` restores the old behavior. Fixes #11.
- Serialized notes carry `created` / `updated` ISO timestamps (null-safe for note objects without them).

Tests included for all of it; suite green under SDK 2.0.0 (40 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)