### PR TITLE
feat: add download_media tool for authenticated media downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Older instructions may ask for your Google password or an app password and call 
 * `add_note_collaborator`: Add a collaborator email to a note
 * `remove_note_collaborator`: Remove a collaborator email from a note
 * `list_note_media`: List media blobs for a note (with media links)
+* `download_media`: Download a note's media (images, drawings, audio) to a local directory through the authenticated session (the raw media links answer 403 to plain HTTP clients)
 
 By default, all destructive and modification operations are restricted to notes that have were created by the MCP server (i.e. have the keep-mcp label). Set `UNSAFE_MODE` to `true` to bypass this restriction.
 

--- a/src/server/cli.py
+++ b/src/server/cli.py
@@ -4,6 +4,7 @@ Provides tools for interacting with Google Keep notes through MCP.
 """
 
 import json
+import os
 import re
 from datetime import datetime, timezone
 from itertools import islice
@@ -19,9 +20,11 @@ except ImportError:  # MCP SDK 1.x: FastMCP became MCPServer in 2.0
 from .keep_api import (
     KEEP_MCP_LABEL,
     can_modify_note,
+    fetch_blob_bytes,
     get_client,
     has_keep_mcp_label,
     is_unsafe_mode,
+    media_extension,
     serialize_label,
     serialize_note,
 )
@@ -470,6 +473,44 @@ def list_note_media(note_id: str) -> str:
         )
 
     return json.dumps(media)
+
+
+@mcp.tool()
+def download_media(note_id: str, dest_dir: str, blob_id: str | None = None) -> str:
+    """Download a note's media (images, drawings, audio) to a local directory.
+
+    The links from list_note_media require Google authentication and answer
+    403 to plain HTTP clients; this tool downloads through the server's own
+    authenticated session instead. Files are written to dest_dir (created if
+    missing) as <blob_id><ext>, with the extension derived from the response
+    Content-Type. blob_id restricts the download to a single blob. Returns a
+    JSON list of {blob_id, type, path, bytes, content_type}.
+    """
+    keep, note = _get_note_or_raise(note_id)
+
+    blobs = [blob for blob in note.blobs if blob_id is None or blob.id == blob_id]
+    if blob_id is not None and not blobs:
+        raise ValueError(f"Blob with ID {blob_id} not found on note {note_id}")
+
+    os.makedirs(dest_dir, exist_ok=True)
+
+    saved = []
+    for blob in blobs:
+        content, content_type = fetch_blob_bytes(keep, blob)
+        path = os.path.join(dest_dir, f"{blob.id}{media_extension(content_type)}")
+        with open(path, "wb") as fh:
+            fh.write(content)
+        saved.append(
+            {
+                "blob_id": blob.id,
+                "type": blob.blob.type.value if blob.blob and blob.blob.type else None,
+                "path": path,
+                "bytes": len(content),
+                "content_type": content_type,
+            }
+        )
+
+    return json.dumps(saved)
 
 
 def main():

--- a/src/server/keep_api.py
+++ b/src/server/keep_api.py
@@ -111,6 +111,57 @@ def serialize_note(note):
 
     return payload
 
+_MEDIA_EXTENSIONS = {
+    'image/png': '.png',
+    'image/jpeg': '.jpg',
+    'image/gif': '.gif',
+    'image/webp': '.webp',
+    'audio/3gpp': '.3gp',
+    'audio/amr': '.amr',
+    'audio/mpeg': '.mp3',
+}
+
+
+def media_extension(content_type):
+    """
+    Map a media response Content-Type to a file extension.
+
+    Args:
+        content_type: The Content-Type header value (may carry parameters)
+
+    Returns:
+        str: A dotted extension, '.bin' when the type is unknown or missing
+    """
+    if not content_type:
+        return '.bin'
+    return _MEDIA_EXTENSIONS.get(content_type.split(';')[0].strip().lower(), '.bin')
+
+
+def fetch_blob_bytes(keep, blob):
+    """
+    Download a media blob through the authenticated Keep session.
+
+    The links returned by getMediaLink() require Google authentication and
+    answer 403 to plain HTTP clients, so the download rides the same session
+    and credentials the server is already authenticated with.
+
+    Args:
+        keep: Authenticated gkeepapi.Keep client
+        blob: A note media blob node
+
+    Returns:
+        tuple: (bytes, content_type) of the downloaded media
+    """
+    url = keep.getMediaLink(blob)
+    media_api = keep._media_api
+    response = media_api._send(url=url, method='GET')
+    if response.status_code in (400, 401, 403):
+        # Some media endpoints reject the OAuth header; retry bare on the same session.
+        response = media_api._session.get(url)
+    response.raise_for_status()
+    return response.content, response.headers.get('Content-Type')
+
+
 def is_unsafe_mode() -> bool:
     return os.getenv('UNSAFE_MODE', '').lower() == 'true'
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -429,6 +429,22 @@ def test_list_note_media(keep):
     assert media[0]["media_link"].startswith("https://media/")
 
 
+def test_download_media_writes_files(keep, monkeypatch, tmp_path):
+    monkeypatch.setattr(cli, "fetch_blob_bytes", lambda k, b: (b"png-bytes", "image/png"))
+    saved = json.loads(cli.download_media("n1", str(tmp_path)))
+    assert saved[0]["blob_id"] == "b1"
+    assert saved[0]["type"] == "IMAGE"
+    assert saved[0]["path"].endswith("b1.png")
+    assert saved[0]["bytes"] == len(b"png-bytes")
+    with open(saved[0]["path"], "rb") as fh:
+        assert fh.read() == b"png-bytes"
+
+
+def test_download_media_unknown_blob(keep, tmp_path):
+    with pytest.raises(ValueError, match="Blob with ID nope not found"):
+        cli.download_media("n1", str(tmp_path), blob_id="nope")
+
+
 def test_modification_guard_blocks_when_unlabeled(keep, monkeypatch):
     keep.notes["n1"].labels = DummyLabels()
     monkeypatch.setattr(cli, "can_modify_note", lambda _: False)

--- a/tests/test_keep_api.py
+++ b/tests/test_keep_api.py
@@ -1,7 +1,12 @@
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
-from server.keep_api import can_modify_note, serialize_note
+from server.keep_api import (
+    can_modify_note,
+    fetch_blob_bytes,
+    media_extension,
+    serialize_note,
+)
 
 
 class DummyLabels:
@@ -88,6 +93,66 @@ def test_serialize_note_without_timestamps_yields_none():
     data = serialize_note(DummyNote())
     assert data["created"] is None
     assert data["updated"] is None
+
+
+def test_media_extension_maps_known_types():
+    assert media_extension("image/png") == ".png"
+    assert media_extension("image/jpeg; charset=utf-8") == ".jpg"
+    assert media_extension("application/octet-stream") == ".bin"
+    assert media_extension(None) == ".bin"
+
+
+class DummyResponse:
+    def __init__(self, status_code=200, content=b"bytes", content_type="image/png"):
+        self.status_code = status_code
+        self.content = content
+        self.headers = {"Content-Type": content_type}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise AssertionError(f"HTTP {self.status_code}")
+
+
+def test_fetch_blob_bytes_rides_authenticated_send():
+    sent = {}
+
+    class DummyMediaAPI:
+        def _send(self, url, method):
+            sent["url"] = url
+            sent["method"] = method
+            return DummyResponse()
+
+    class DummyKeep:
+        _media_api = DummyMediaAPI()
+
+        def getMediaLink(self, blob):
+            return f"https://media/{blob.id}"
+
+    content, content_type = fetch_blob_bytes(DummyKeep(), SimpleNamespace(id="b1"))
+    assert sent == {"url": "https://media/b1", "method": "GET"}
+    assert content == b"bytes"
+    assert content_type == "image/png"
+
+
+def test_fetch_blob_bytes_retries_bare_on_403():
+    class DummySession:
+        def get(self, url):
+            return DummyResponse(content=b"bare-bytes")
+
+    class DummyMediaAPI:
+        _session = DummySession()
+
+        def _send(self, url, method):
+            return DummyResponse(status_code=403)
+
+    class DummyKeep:
+        _media_api = DummyMediaAPI()
+
+        def getMediaLink(self, blob):
+            return "https://media/b1"
+
+    content, _ = fetch_blob_bytes(DummyKeep(), SimpleNamespace(id="b1"))
+    assert content == b"bare-bytes"
 
 
 def test_can_modify_note_respects_label(monkeypatch):


### PR DESCRIPTION
## Problem

`list_note_media` returns direct media links, but those links require Google authentication — any plain HTTP client (which is what MCP consumers are) gets a 403. So a client can discover a note's drawings and photos, but has no way to actually retrieve them.

## Solution

New tool `download_media(note_id, dest_dir, blob_id?)` that downloads media through the session the server is already authenticated with — no new credentials, no extra setup:

- resolves each blob with `getMediaLink()`, fetches it via the authenticated session, with a bare-session retry in case an endpoint rejects the auth header
- writes to `dest_dir` (created if missing) as `<blob_id><ext>`, extension derived from the response Content-Type (`.bin` fallback)
- optional `blob_id` limits the download to a single blob
- returns `[{blob_id, type, path, bytes, content_type}]`
- read-only toward Keep: works on any note regardless of the keep-mcp label, like the other read tools

Writing files rather than returning base64 is deliberate: media can be large, stdio MCP servers run local to their client, and a file path keeps image bytes out of the model's context window.

## Testing

- unit tests for the tool (happy path + unknown blob), the extension mapping, and both fetch paths — suite at 45 tests, ruff clean
- proven live against a real account: 7 blobs across 6 notes (drawings + photos), all downloaded with correct extensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)